### PR TITLE
Adds snapshot publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      # Specify the version you desire here
+      # See: https://circleci.com/developer/images/image/cimg/base
+      - image: cimg/base:current
+
+    # Add steps to the job
+    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      # Checkout the code as the first step.
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,52 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine.
 # See: https://circleci.com/docs/configuration-reference
+
+# For a detailed guide to building and testing on Android, read the docs:
+# https://circleci.com/docs/language-android/ for more details.
 version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/orb-intro/
+orbs:
+  # See the Android orb documentation here: https://circleci.com/developer/orbs/orb/circleci/android
+  android: circleci/android@2.4.0
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
-    docker:
-      # Specify the version you desire here
-      # See: https://circleci.com/developer/images/image/cimg/base
-      - image: cimg/base:current
+  # Below is the definition of your job to build and test your app, you can rename and customize it as you want.
+  build-and-test:
+    # These next lines define the Android machine image executor.
+    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/developer/orbs/orb/circleci/android#executors-android-machine
+    executor:
+      name: android/android-machine
+      tag: default
 
     # Add steps to the job
     # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
     steps:
       # Checkout the code as the first step.
       - checkout
+
+      # The next step will run the unit tests
+      - android/run-tests:
+          test-command: ./gradlew lint testDebug --continue
+
+      # Then start the emulator and run the Instrumentation tests!
+      - android/start-emulator-and-run-tests:
+          test-command: ./gradlew connectedDebugAndroidTest
+          system-image: system-images;android-25;google_apis;x86
+
+      # And finally run the release build
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: Assemble release build
+          command: |
+            ./gradlew assembleRelease
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
+  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run.
     jobs:
-      - say-hello
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executors:
-  docker-base:
+  jdk17:
     docker:
-      - image: cimg/base:2024.06
+      - image: cimg/openjdk:17.0
   xcode15:
     macos:
       xcode: 15.4.0
@@ -34,7 +34,7 @@ commands:
 
 jobs:
   detekt:
-    executor: docker-base
+    executor: jdk17
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ executors:
   jdk:
     docker:
       - image: cimg/openjdk:17.0
-    environment:
-      JVM_OPTS: -Xmx6g
-      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
 orbs:
   android: circleci/android@2.5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
               echo "$version is not a SNAPSHOT version. Exiting..."
               exit 1
             else
-              echo "$version is a SNAPSHOT version. Continuing..."
+              echo "$version is a SNAPSHOT version. Proceeding..."
             fi
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,23 @@ commands:
       - run:
           name: Install Android SDK platform tools
           command: sdkmanager "platform-tools"
+  require-snapshot-version:
+    description: Check that the current version is a SNAPSHOT version
+    steps:
+      - run:
+          name: Check that the current version is a SNAPSHOT version
+          command: |
+            set -euo pipefail
+            file_path="gradle/libs.versions.toml"
+            version=$(grep 'revenuecat-kmp = ' "$file_path" | awk -F ' = ' '{print $2}' | tr -d '"')
+            if [[ ! "$version" =~ -SNAPSHOT$ ]]; then
+              echo "$version is not a SNAPSHOT version. Exiting..."
+              exit 1
+            else
+              echo "$version is a SNAPSHOT version. Continuing..."
+            fi
 
 executors:
-  jdk17:
-    docker:
-      - image: cimg/openjdk:17.0
   xcode15:
     macos:
       xcode: 15.4.0
@@ -32,39 +44,12 @@ executors:
       HOMEBREW_NO_AUTO_UPDATE: 1
 
 jobs:
-  detekt:
-    executor: jdk17
-    shell: /bin/bash --login -o pipefail
-    steps:
-      - checkout
-      - android/restore-gradle-cache
-      - run:
-          name: Run Detekt on commonMain
-          command: ./gradlew detektCommonMain
-      - android/save-gradle-cache
-      - run:
-          name: Collect Detekt HTML reports
-          command: mkdir -p artifacts/detekt && mv build/reports/detekt/*.html artifacts/detekt/
-      - store_artifacts:
-          path: artifacts/detekt
-          destination: detekt
-
-  validate-binary-compatibility:
-    executor: xcode15
-    steps:
-      - install-android-sdk-on-macos
-      - checkout
-      - android/restore-gradle-cache
-      - run:
-          name: Validate binary compatibility
-          command: ./gradlew apiCheck
-      - android/save-gradle-cache
-
   deploy-snapshot:
     executor: xcode15
     steps:
-      - install-android-sdk-on-macos
       - checkout
+      - require-snapshot-version
+      - install-android-sdk-on-macos
       - android/restore-gradle-cache
       - android/restore-build-cache
       - run:
@@ -81,12 +66,13 @@ jobs:
       - android/save-build-cache
 
 workflows:
-  build-test-deploy:
+  on-main:
+    # On all pushes to main, except when it's a scheduled pipeline.
     when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+      and:
+        - equal: [ main, << pipeline.git.branch >> ]
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - detekt
-      - validate-binary-compatibility
       - deploy-snapshot:
           context: maven-central-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ executors:
   jdk:
     docker:
       - image: cimg/openjdk:17.0
+  xcode15:
+    macos:
+      xcode: 15.4.0
 
 orbs:
   android: circleci/android@2.5.0
@@ -46,6 +49,17 @@ jobs:
       - store_artifacts:
           path: artifacts/detekt
           destination: detekt
+  validate-binary-compatibility:
+    executor: xcode15
+    steps:
+      - checkout
+      - install-sdkman
+      - android/restore-gradle-cache
+      - run:
+          name: Validate binary compatibility
+          command: ./gradlew apiCheck
+      - android/save-gradle-cache
+
 
 workflows:
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,12 @@ commands:
     description: Install the Android SDK on macOS
     parameters:
       platform-version:
-        description: The platform version to install, e.g. '34'.
-        type: integer
+        description: The platform version to install, e.g. "34".
+        type: string
+      build-tools-version:
+        description: The build tools version to install, e.g. "34.0.0".
+        type: string
+        default: "<<parameters.platform-version>>.0.0"
     steps:
       - run:
           name: Install Android SDK commandline tools
@@ -24,7 +28,7 @@ commands:
       - android/accept-licenses
       - run:
           name: Install Android SDK
-          command: sdkmanager "platform-tools" "platforms;android-<<parameters.platform-version>>" "build-tools;34.0.0"
+          command: sdkmanager "platform-tools" "platforms;android-<<parameters.platform-version>>" "build-tools;<<parameters.build-tools-version>>"
 
 executors:
   jdk17:
@@ -58,7 +62,7 @@ jobs:
     executor: xcode15
     steps:
       - install-android-sdk-on-macos:
-          platform-version: 34
+          platform-version: "34"
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
       - android/accept-licenses
       - run:
           command: sdkmanager "platform-tools" "platforms;android-34"
+      - run:
+          command: echo $ANDROID_HOME
+      - run:
+          command: ls -lha $ANDROID_HOME
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
           command: brew install --cask android-commandlinetools
       - run:
           command: sdkmanager "platform-tools" "platforms;android-34"
-      - android/accept-licences
+      - android/accept-licenses
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: sdkmanager --list
       - run:
           command: |
-            echo 'export ANDROID_HOME="$HOME/Library/Android/sdk"' >> "$BASH_ENV"
+            echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - run:
           command: echo $ANDROID_HOME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ commands:
             echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - android/accept-licenses
-      - run:
-          name: Install Android SDK
-          command: sdkmanager "platform-tools" "platforms;android-<<parameters.platform-version>>" "build-tools;<<parameters.build-tools-version>>"
+#      - run:
+#          name: Install Android SDK
+#          command: sdkmanager "platform-tools" "platforms;android-<<parameters.platform-version>>" "build-tools;<<parameters.build-tools-version>>"
 
 executors:
   jdk17:
@@ -55,6 +55,7 @@ jobs:
       - store_artifacts:
           path: artifacts/detekt
           destination: detekt
+
   validate-binary-compatibility:
     executor: xcode15
     steps:
@@ -68,6 +69,26 @@ jobs:
           command: ./gradlew apiCheck
       - android/save-gradle-cache
 
+#  deploy-snapshot:
+#    executor: xcode15
+#    steps:
+#      - install-android-sdk-on-macos:
+#          platform-version: "34"
+#          build-tools-version: "34.0.0"
+#      - checkout
+#      - android/restore-gradle-cache:
+#      - android/restore-build-cache:
+#      - prepare-signing-key
+#      - run:
+#        name: Publish snapshot to Maven Central
+#        command: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
+#        env:
+#          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.RC_SONATYPE_CENTRAL_USERNAME }}
+#          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.RC_SONATYPE_CENTRAL_PASSWORD }}
+#          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.RC_ARTIFACT_SIGNING_PRIVATE_KEY }}
+#          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.RC_ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
+#      - android/save-gradle-cache:
+#      - android/save-build-cache:
 
 workflows:
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
             set -euo pipefail
             file_path="gradle/libs.versions.toml"
             version=$(grep 'revenuecat-kmp = ' "$file_path" | awk -F ' = ' '{print $2}' | tr -d '"')
-            if [[ ! "$version" =~ -SNAPSHOT$ ]]; then
+            if [[ "$version" =~ -SNAPSHOT$ ]]; then
               echo "$version is not a SNAPSHOT version. Exiting..."
               exit 1
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
     # On all pushes to main, except when it's a scheduled pipeline.
     when:
       and:
-        - equal: [ main, << pipeline.git.branch >> ]
+        #- equal: [ main, << pipeline.git.branch >> ]
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,12 @@
 version: 2.1
 
-aliases:
-  android-executor: &android-executor
-    executor:
-      name: android/android-docker
-      resource-class: large
-      tag: 2024.04.1
-    environment:
-      JVM_OPTS: -Xmx6g
-      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
-
 executors:
   jdk:
     docker:
       - image: cimg/openjdk:17.0
+    environment:
+      JVM_OPTS: -Xmx6g
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
 orbs:
   android: circleci/android@2.5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 executors:
-  jdk:
+  docker-base:
     docker:
-      - image: cimg/openjdk:17.0
+      - image: cimg/base:2024.06
   xcode15:
     macos:
       xcode: 15.4.0
@@ -34,7 +34,7 @@ commands:
 
 jobs:
   detekt:
-    executor: jdk
+    executor: docker-base
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,6 @@ orbs:
 commands:
   install-android-sdk-on-macos:
     description: Install the Android SDK on macOS
-    parameters:
-      platform-version:
-        description: The platform version to install, e.g. "34".
-        type: string
-      build-tools-version:
-        description: The build tools version to install, e.g. "34.0.0".
-        type: string
     steps:
       - run:
           name: Install Android SDK commandline tools
@@ -23,9 +16,9 @@ commands:
             echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - android/accept-licenses
-#      - run:
-#          name: Install Android SDK
-#          command: sdkmanager "platform-tools" "platforms;android-<<parameters.platform-version>>" "build-tools;<<parameters.build-tools-version>>"
+      - run:
+          name: Install Android SDK platform tools
+          command: sdkmanager "platform-tools"
 
 executors:
   jdk17:
@@ -60,8 +53,6 @@ jobs:
     executor: xcode15
     steps:
       - install-android-sdk-on-macos:
-          platform-version: "34"
-          build-tools-version: "34.0.0"
       - checkout
       - android/restore-gradle-cache
       - run:
@@ -73,8 +64,6 @@ jobs:
 #    executor: xcode15
 #    steps:
 #      - install-android-sdk-on-macos:
-#          platform-version: "34"
-#          build-tools-version: "34.0.0"
 #      - checkout
 #      - android/restore-gradle-cache:
 #      - android/restore-build-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,10 @@ jobs:
           command: ./gradlew detektCommonMain
       - android/save-gradle-cache
       - store_artifacts:
-          path: build/reports/detekt/*.html
+          path: build/reports/detekt
           destination: detekt
+      - store_test_results:
+          path: build/reports/detekt
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,6 @@ jobs:
           path: artifacts/detekt
           destination: detekt
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
   build-test-deploy:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,11 @@ jobs:
           name: Run Detekt on commonMain
           command: ./gradlew detektCommonMain
       - android/save-gradle-cache
+      - run:
+          name: Collect Detekt HTML reports
+          command: mv build/reports/detekt/*.html artifacts/detekt/
       - store_artifacts:
-          path: build/reports/detekt
+          path: artifacts/detekt
           destination: detekt
 
 # Orchestrate jobs using workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ executors:
     resource_class: macos.m1.medium.gen1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
+      # This is where sdkmanager installs the Android SDK.
+      ANDROID_HOME: $HOME/Library/Android/sdk
+      PATH: $ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH
 
 orbs:
   android: circleci/android@2.5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
           command: echo $JAVA_HOME
       - run:
           command: brew install --cask android-commandlinetools
+      - android/accept-licenses
       - run:
           command: sdkmanager "platform-tools" "platforms;android-34"
-      - android/accept-licenses
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
             set -euo pipefail
             file_path="gradle/libs.versions.toml"
             version=$(grep 'revenuecat-kmp = ' "$file_path" | awk -F ' = ' '{print $2}' | tr -d '"')
-            if [[ "$version" =~ -SNAPSHOT$ ]]; then
+            if [[ ! "$version" =~ -SNAPSHOT$ ]]; then
               echo "$version is not a SNAPSHOT version. Exiting..."
               exit 1
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ jobs:
           name: Run Detekt on commonMain
           command: ./gradlew detektCommonMain
       - android/save-gradle-cache
+      - store_artifacts:
+          path: build/reports
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,25 @@
 version: 2.1
 
+orbs:
+  android: circleci/android@2.5.0
+
+commands:
+  install-android-sdk-on-macos:
+    description: Install the Android SDK on macOS
+    steps:
+      - run:
+          name: Install the Android SDK commandline tools
+          command: brew install --cask android-commandlinetools
+      - run:
+          name: Set the Android SDK environment variables
+          command: |
+            echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"
+            echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
+      - android/accept-licenses
+      - run:
+          name: Install Android platform 34
+          command: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
 executors:
   jdk17:
     docker:
@@ -10,9 +30,6 @@ executors:
     resource_class: macos.m1.medium.gen1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-
-orbs:
-  android: circleci/android@2.5.0
 
 jobs:
   detekt:
@@ -34,35 +51,7 @@ jobs:
   validate-binary-compatibility:
     executor: xcode15
     steps:
-      - run:
-          command: which -a java
-      - run:
-          command: java -version
-      - run:
-          command: /usr/libexec/java_home -V
-      - run:
-          command: echo $JAVA_HOME
-      - run:
-          command: brew install --cask android-commandlinetools
-      - android/accept-licenses
-      - run:
-          command: sdkmanager "platform-tools" "platforms;android-34"
-      - run:
-          command: which -a sdkmanager
-      - run:
-          command: sdkmanager --list
-      - run:
-          command: |
-            echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"
-            echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
-      - run:
-          command: echo $ANDROID_HOME
-      - run:
-          command: echo "$HOMEBREW_PREFIX/share/android-commandlinetools"
-      - run:
-          command: ls -lha "$HOMEBREW_PREFIX/share/android-commandlinetools"
-      - run:
-          command: ls -lha $ANDROID_HOME
+      - install-android-sdk-on-macos
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
       - android/save-gradle-cache
       - run:
           name: Collect Detekt HTML reports
-          command: mv build/reports/detekt/*.html artifacts/detekt/
+          command: mkdir -p artifacts/detekt && mv build/reports/detekt/*.html artifacts/detekt/
       - store_artifacts:
           path: artifacts/detekt
           destination: detekt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ executors:
     macos:
       xcode: 15.4.0
     resource_class: macos.m1.medium.gen1
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
 
 orbs:
   android: circleci/android@2.5.0
@@ -32,6 +34,14 @@ jobs:
   validate-binary-compatibility:
     executor: xcode15
     steps:
+      - run:
+          command: which -a java
+      - run:
+          command: java -version
+      - run:
+          command: /usr/libexec/java_home
+      - run:
+          command: brew install --cask android-commandlinetools
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ executors:
   xcode15:
     macos:
       xcode: 15.4.0
+    resource_class: macos.m1.medium.gen1
 
 orbs:
   android: circleci/android@2.5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ jobs:
       - run:
           command: printenv
       - run:
+          command: echo $ORG_GRADLE_PROJECT_mavenCentralUsername
+      - run:
           name: Publish snapshot to Maven Central
           command: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
       - android/save-gradle-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,9 @@ jobs:
       - run:
           command: java -version
       - run:
-          command: /usr/libexec/java_home
+          command: /usr/libexec/java_home -V
+      - run:
+          command: echo $JAVA_HOME
       - run:
           command: brew install --cask android-commandlinetools
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,25 @@ orbs:
 commands:
   install-android-sdk-on-macos:
     description: Install the Android SDK on macOS
+    parameters:
+      platform-version:
+        description: The platform version to install, e.g. '34'.
+        type: integer
     steps:
       - run:
-          name: Install the Android SDK commandline tools
+          name: Install Android SDK commandline tools
           command: brew install --cask android-commandlinetools
       - run:
-          name: Set the Android SDK environment variables
+          command: sdkmanager --list
+      - run:
+          name: Set Android SDK environment variables
           command: |
             echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - android/accept-licenses
       - run:
-          name: Install Android platform 34
-          command: sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+          name: Install Android SDK
+          command: sdkmanager "platform-tools" "platforms;android-<<parameters.platform-version>>" "build-tools;34.0.0"
 
 executors:
   jdk17:
@@ -51,7 +57,8 @@ jobs:
   validate-binary-compatibility:
     executor: xcode15
     steps:
-      - install-android-sdk-on-macos
+      - install-android-sdk-on-macos:
+          platform-version: 34
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ jobs:
 
   deploy-snapshot:
     executor: xcode15
-    #shell: /bin/bash --login -euo pipefail
     steps:
       - install-android-sdk-on-macos
       - checkout
@@ -76,12 +75,8 @@ jobs:
             echo 'export ORG_GRADLE_PROJECT_signingInMemoryKey="$SIGNING_GPG_IN_MEMORY"' >> "$BASH_ENV"
             echo 'export ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="$GPG_SIGNING_KEY_PW_NEW"' >> "$BASH_ENV"
       - run:
-          command: printenv
-      - run:
-          command: echo $ORG_GRADLE_PROJECT_mavenCentralUsername
-      - run:
           name: Publish snapshot to Maven Central
-          command: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
+          command: ./gradlew publishAllPublicationsToMavenCentralRepository
       - android/save-gradle-cache
       - android/save-build-cache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
 jobs:
   detekt:
     <<: *android-executor
-    shell: /bin/bash --login set -euo pipefail
+    shell: /bin/bash --login -euo pipefail
     steps:
       - checkout
       - install-sdkman

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ jobs:
           command: ./gradlew detektCommonMain
       - android/save-gradle-cache
       - store_artifacts:
-          path: build/reports
+          path: build/reports/detekt/*.html
+          destination: detekt
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ commands:
           name: Install Android SDK commandline tools
           command: brew install --cask android-commandlinetools
       - run:
-          command: sdkmanager --list
-      - run:
           name: Set Android SDK environment variables
           command: |
             echo 'export ANDROID_HOME="$HOMEBREW_PREFIX/share/android-commandlinetools"' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
     # On all pushes to main, except when it's a scheduled pipeline.
     when:
       and:
-        #- equal: [ main, << pipeline.git.branch >> ]
+        - equal: [ main, << pipeline.git.branch >> ]
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,3 +68,4 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - detekt
+      - validate-binary-compatibility

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,11 @@ aliases:
       JVM_OPTS: -Xmx6g
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
+executors:
+  jdk:
+    docker:
+      - image: cimg/openjdk:17.0
+
 orbs:
   android: circleci/android@2.5.0
 
@@ -35,7 +40,7 @@ commands:
 
 jobs:
   detekt:
-    <<: *android-executor
+    executor: jdk
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,6 @@ jobs:
       - store_artifacts:
           path: build/reports/detekt
           destination: detekt
-      - store_test_results:
-          path: build/reports/detekt
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,9 @@ jobs:
           command: echo $JAVA_HOME
       - run:
           command: brew install --cask android-commandlinetools
+      - run:
+          command: sdkmanager "platform-tools" "platforms;android-34"
+      - android/accept-licences
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,52 +1,57 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
-
-# For a detailed guide to building and testing on Android, read the docs:
-# https://circleci.com/docs/language-android/ for more details.
 version: 2.1
 
-# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
-# See: https://circleci.com/docs/orb-intro/
-orbs:
-  # See the Android orb documentation here: https://circleci.com/developer/orbs/orb/circleci/android
-  android: circleci/android@2.4.0
-
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
-jobs:
-  # Below is the definition of your job to build and test your app, you can rename and customize it as you want.
-  build-and-test:
-    # These next lines define the Android machine image executor.
-    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/developer/orbs/orb/circleci/android#executors-android-machine
+aliases:
+  android-executor: &android-executor
     executor:
-      name: android/android-machine
-      tag: default
+      name: android/android-docker
+      resource-class: large
+      tag: 2024.04.1
+    environment:
+      JVM_OPTS: -Xmx6g
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 
-    # Add steps to the job
-    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
+orbs:
+  android: circleci/android@2.5.0
+
+commands:
+  install-sdkman:
+    description: Install SDKMAN
     steps:
-      # Checkout the code as the first step.
-      - checkout
-
-      # The next step will run the unit tests
-      - android/run-tests:
-          test-command: ./gradlew lint testDebug --continue
-
-      # Then start the emulator and run the Instrumentation tests!
-      - android/start-emulator-and-run-tests:
-          test-command: ./gradlew connectedDebugAndroidTest
-          system-image: system-images;android-25;google_apis;x86
-
-      # And finally run the release build
       - run:
-          name: Assemble release build
+          name: Installing SDKMAN
           command: |
-            ./gradlew assembleRelease
+            if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
+              echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
+              source $BASH_ENV
+            else
+              echo "Error installing SDKMAN, continuing with default Java" >&2
+            fi
+      - run:
+          name: Setup Java environment
+          command: |
+            if ! sdk env install; then
+              echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
+            fi
+
+jobs:
+  detekt:
+    <<: *android-executor
+    shell: /bin/bash --login set -euo pipefail
+    steps:
+      - checkout
+      - install-sdkman
+      - android/restore-gradle-cache
+      - run:
+          name: Run Detekt on commonMain
+          command: ./gradlew detektCommonMain
+      - android/save-gradle-cache
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  build-test-deploy:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - build-and-test
+      - detekt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   deploy-snapshot:
     executor: xcode15
-    shell: /bin/bash --login -euo pipefail
+    #shell: /bin/bash --login -euo pipefail
     steps:
       - install-android-sdk-on-macos
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,33 +12,12 @@ executors:
 orbs:
   android: circleci/android@2.5.0
 
-commands:
-  install-sdkman:
-    description: Install SDKMAN
-    steps:
-      - run:
-          name: Installing SDKMAN
-          command: |
-            if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
-              echo -e '\nsource "$HOME/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-              source $BASH_ENV
-            else
-              echo "Error installing SDKMAN, continuing with default Java" >&2
-            fi
-      - run:
-          name: Setup Java environment
-          command: |
-            if ! sdk env install; then
-              echo "Error installing Java SDK through SDKMAN, continuing with default Java" >&2
-            fi
-
 jobs:
   detekt:
     executor: jdk17
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - install-sdkman
       - android/restore-gradle-cache
       - run:
           name: Run Detekt on commonMain
@@ -54,7 +33,6 @@ jobs:
     executor: xcode15
     steps:
       - checkout
-      - install-sdkman
       - android/restore-gradle-cache
       - run:
           name: Validate binary compatibility

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ executors:
     resource_class: macos.m1.medium.gen1
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-      # This is where sdkmanager installs the Android SDK.
-      ANDROID_HOME: $HOME/Library/Android/sdk
 
 orbs:
   android: circleci/android@2.5.0
@@ -49,6 +47,10 @@ jobs:
       - android/accept-licenses
       - run:
           command: sdkmanager "platform-tools" "platforms;android-34"
+      - run:
+          command: |
+            echo 'export ANDROID_HOME="$HOME/Library/Android/sdk"' >> "$BASH_ENV"
+            echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - run:
           command: echo $ANDROID_HOME
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ executors:
       HOMEBREW_NO_AUTO_UPDATE: 1
       # This is where sdkmanager installs the Android SDK.
       ANDROID_HOME: $HOME/Library/Android/sdk
-      PATH: $ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH
 
 orbs:
   android: circleci/android@2.5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   validate-binary-compatibility:
     executor: xcode15
     steps:
-      - install-android-sdk-on-macos:
+      - install-android-sdk-on-macos
       - checkout
       - android/restore-gradle-cache
       - run:
@@ -63,7 +63,7 @@ jobs:
 #  deploy-snapshot:
 #    executor: xcode15
 #    steps:
-#      - install-android-sdk-on-macos:
+#      - install-android-sdk-on-macos
 #      - checkout
 #      - android/restore-gradle-cache:
 #      - android/restore-build-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ commands:
           name: Installing SDKMAN
           command: |
             if curl -s "https://get.sdkman.io?rcupdate=false" | bash; then
-              echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
+              echo -e '\nsource "$HOME/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
               source $BASH_ENV
             else
               echo "Error installing SDKMAN, continuing with default Java" >&2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ executors:
       xcode: 15.4.0
     resource_class: macos.m1.medium.gen1
     environment:
+      # Avoid waiting for Homebrew to auto update existing packages, as everything we care about is
+      # freshly installed.
       HOMEBREW_NO_AUTO_UPDATE: 1
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,24 +60,28 @@ jobs:
           command: ./gradlew apiCheck
       - android/save-gradle-cache
 
-#  deploy-snapshot:
-#    executor: xcode15
-#    steps:
-#      - install-android-sdk-on-macos
-#      - checkout
-#      - android/restore-gradle-cache:
-#      - android/restore-build-cache:
-#      - prepare-signing-key
-#      - run:
-#        name: Publish snapshot to Maven Central
-#        command: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
-#        env:
-#          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.RC_SONATYPE_CENTRAL_USERNAME }}
-#          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.RC_SONATYPE_CENTRAL_PASSWORD }}
-#          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.RC_ARTIFACT_SIGNING_PRIVATE_KEY }}
-#          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.RC_ARTIFACT_SIGNING_PRIVATE_KEY_PASSWORD }}
-#      - android/save-gradle-cache:
-#      - android/save-build-cache:
+  deploy-snapshot:
+    executor: xcode15
+    shell: /bin/bash --login -euo pipefail
+    steps:
+      - install-android-sdk-on-macos
+      - checkout
+      - android/restore-gradle-cache
+      - android/restore-build-cache
+      - run:
+          name: Set environment variables for publishing
+          command: |
+            echo 'export ORG_GRADLE_PROJECT_mavenCentralUsername="$SONATYPE_NEXUS_TOKEN_USERNAME"' >> "$BASH_ENV"
+            echo 'export ORG_GRADLE_PROJECT_mavenCentralPassword="$SONATYPE_NEXUS_TOKEN_PASSWORD"' >> "$BASH_ENV"
+            echo 'export ORG_GRADLE_PROJECT_signingInMemoryKey="$SIGNING_GPG_IN_MEMORY"' >> "$BASH_ENV"
+            echo 'export ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="$GPG_SIGNING_KEY_PW_NEW"' >> "$BASH_ENV"
+      - run:
+          command: printenv
+      - run:
+          name: Publish snapshot to Maven Central
+          command: ./gradlew publishAllPublicationsToCentralPortal --no-configuration-cache
+      - android/save-gradle-cache
+      - android/save-build-cache
 
 workflows:
   build-test-deploy:
@@ -87,3 +91,5 @@ workflows:
     jobs:
       - detekt
       - validate-binary-compatibility
+      - deploy-snapshot:
+          context: maven-central-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
 jobs:
   detekt:
     <<: *android-executor
-    shell: /bin/bash --login -euo pipefail
+    shell: /bin/bash --login -o pipefail
     steps:
       - checkout
       - install-sdkman

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ commands:
       build-tools-version:
         description: The build tools version to install, e.g. "34.0.0".
         type: string
-        default: "<<parameters.platform-version>>.0.0"
     steps:
       - run:
           name: Install Android SDK commandline tools
@@ -63,6 +62,7 @@ jobs:
     steps:
       - install-android-sdk-on-macos:
           platform-version: "34"
+          build-tools-version: "34.0.0"
       - checkout
       - android/restore-gradle-cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,19 @@ jobs:
       - run:
           command: sdkmanager "platform-tools" "platforms;android-34"
       - run:
+          command: which -a sdkmanager
+      - run:
+          command: sdkmanager --list
+      - run:
           command: |
             echo 'export ANDROID_HOME="$HOME/Library/Android/sdk"' >> "$BASH_ENV"
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - run:
           command: echo $ANDROID_HOME
+      - run:
+          command: echo "$HOMEBREW_PREFIX/share/android-commandlinetools"
+      - run:
+          command: ls -lha "$HOMEBREW_PREFIX/share/android-commandlinetools"
       - run:
           command: ls -lha $ANDROID_HOME
       - checkout

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.6-librca

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,0 @@
-# Enable auto-env through the sdkman_auto_env config
-# Add key=value pairs of SDKs to use below
-java=17.0.6-librca

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/plugin/LibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/plugin/LibraryConventionPlugin.kt
@@ -25,7 +25,6 @@ class LibraryConventionPlugin : Plugin<Project> {
             apply("dev.adamko.dokkatoo-html")
             apply("io.gitlab.arturbosch.detekt")
             apply("com.vanniktech.maven.publish")
-            apply("com.gradleup.nmcp")
         }
 
         extensions.configure<KotlinMultiplatformExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,9 +2,8 @@
 
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.MavenPublishPlugin
+import com.vanniktech.maven.publish.SonatypeHost
 import io.gitlab.arturbosch.detekt.Detekt
-import nmcp.NmcpExtension
-import nmcp.NmcpPlugin
 import org.gradle.configurationcache.extensions.capitalized
 
 plugins {
@@ -19,45 +18,27 @@ plugins {
     alias(libs.plugins.adamko.dokkatoo.html)
     alias(libs.plugins.arturbosch.detekt).apply(false)
     alias(libs.plugins.vanniktech.mavenPublish).apply(false)
-    alias(libs.plugins.gradleup.nmcp).apply(false)
 }
 
 allprojects {
-    group = "" // FIXME Check publishing
+    group = "com.revenuecat.purchases"
     version = rootProject.libs.versions.revenuecat.kmp.get()
-
-    // NmcpPlugin publishes to a local repo when running assemble, meaning we need signing
-    // credentials for every assemble. This avoids that.
-    if (gradle.startParameter.taskNames.contains("publishAllPublicationsToCentralPortal")) {
-        // Remove when https://github.com/vanniktech/gradle-maven-publish-plugin/issues/722 is fixed.
-        plugins.withType<NmcpPlugin> {
-            configure<NmcpExtension>() {
-                publishAllPublications {
-                    username = System.getenv("ORG_GRADLE_PROJECT_mavenCentralUsername")
-                    password = System.getenv("ORG_GRADLE_PROJECT_mavenCentralPassword")
-                    publicationType = "AUTOMATIC"
-                }
-            }
-        }
-    }
 
     plugins.withType<MavenPublishPlugin> {
         configure<MavenPublishBaseExtension> {
-            // Re-enable when https://github.com/vanniktech/gradle-maven-publish-plugin/issues/722
-            // is fixed.
-            // publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
+            publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
             signAllPublications()
 
             coordinates(
                 groupId = group.toString(),
-                artifactId = "kobankat-${project.name}",
+                artifactId = "purchases-kmp-${project.name}",
                 version = version.toString()
             )
             pom {
-                name.set("KobanKat (${project.name})")
-                description.set("RevenueCat SDK for Kotlin Multiplatform")
+                name.set("purchases-kmp-(${project.name})")
+                description.set("Mobile subscriptions in hours, not months.")
                 inceptionYear.set("2024")
-                url.set("https://github.com/JayShortway/kobankat")
+                url.set("https://github.com/RevenueCat/purchases-kmp")
                 licenses {
                     license {
                         name.set("The MIT License (MIT)")
@@ -67,15 +48,15 @@ allprojects {
                 }
                 developers {
                     developer {
-                        id.set("JayShortway")
-                        name.set("Jay Shortway")
-                        url.set("https://github.com/JayShortway")
+                        id.set("revenuecat")
+                        name.set("RevenueCat, Inc.")
+                        url.set("https://www.revenuecat.com/")
                     }
                 }
                 scm {
-                    url.set("https://github.com/JayShortway/kobankat")
-                    connection.set("scm:git:https://github.com/JayShortway/kobankat.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/JayShortway/kobankat.git")
+                    url.set("https://github.com/RevenueCat/purchases-kmp")
+                    connection.set("scm:git:git://github.com/RevenueCat/purchases-kmp.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/RevenueCat/purchases-kmp.git")
                 }
             }
         }

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -5,7 +5,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <core>
+// Library unique name: <com.revenuecat.purchases:core>
 abstract interface com.revenuecat.purchases.kmp.models/PurchasingData { // com.revenuecat.purchases.kmp.models/PurchasingData|null[0]
     abstract val productId // com.revenuecat.purchases.kmp.models/PurchasingData.productId|{}productId[0]
         abstract fun <get-productId>(): kotlin/String // com.revenuecat.purchases.kmp.models/PurchasingData.productId.<get-productId>|<get-productId>(){}[0]

--- a/datetime/api/datetime.klib.api
+++ b/datetime/api/datetime.klib.api
@@ -5,7 +5,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <datetime>
+// Library unique name: <com.revenuecat.purchases:datetime>
 final val com.revenuecat.purchases.kmp.datetime/allExpirationInstants // com.revenuecat.purchases.kmp.datetime/allExpirationInstants|@cocoapods.PurchasesHybridCommon.RCCustomerInfo{}allExpirationInstants[0]
     final fun (cocoapods.PurchasesHybridCommon/RCCustomerInfo).<get-allExpirationInstants>(): kotlin.collections/Map<kotlin/String, kotlinx.datetime/Instant?> // com.revenuecat.purchases.kmp.datetime/allExpirationInstants.<get-allExpirationInstants>|<get-allExpirationInstants>@cocoapods.PurchasesHybridCommon.RCCustomerInfo(){}[0]
 final val com.revenuecat.purchases.kmp.datetime/allPurchaseInstants // com.revenuecat.purchases.kmp.datetime/allPurchaseInstants|@cocoapods.PurchasesHybridCommon.RCCustomerInfo{}allPurchaseInstants[0]

--- a/either/api/either.klib.api
+++ b/either/api/either.klib.api
@@ -5,7 +5,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <either>
+// Library unique name: <com.revenuecat.purchases:either>
 final class com.revenuecat.purchases.kmp.either/FailedPurchase { // com.revenuecat.purchases.kmp.either/FailedPurchase|null[0]
     constructor <init>(com.revenuecat.purchases.kmp/PurchasesError, kotlin/Boolean) // com.revenuecat.purchases.kmp.either/FailedPurchase.<init>|<init>(com.revenuecat.purchases.kmp.PurchasesError;kotlin.Boolean){}[0]
     final fun component1(): com.revenuecat.purchases.kmp/PurchasesError // com.revenuecat.purchases.kmp.either/FailedPurchase.component1|component1(){}[0]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,9 +29,8 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 codingfeline-buildkonfig = { id = "com.codingfeline.buildkonfig", version = "0.15.1" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-gradleup-nmcp = { id = "com.gradleup.nmcp", version = "0.0.4" }
 jetbrains-compose = { id = "org.jetbrains.compose", version = "1.6.10" }
 kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.15.0-Beta.2" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.28.0" }

--- a/paywalls/api/paywalls.klib.api
+++ b/paywalls/api/paywalls.klib.api
@@ -5,7 +5,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <paywalls>
+// Library unique name: <com.revenuecat.purchases:paywalls>
 abstract interface com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener { // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener|null[0]
     open fun onPurchaseCancelled() // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onPurchaseCancelled|onPurchaseCancelled(){}[0]
     open fun onPurchaseCompleted(cocoapods.PurchasesHybridCommon/RCCustomerInfo, cocoapods.PurchasesHybridCommon/RCStoreTransaction) // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onPurchaseCompleted|onPurchaseCompleted(cocoapods.PurchasesHybridCommon.RCCustomerInfo;cocoapods.PurchasesHybridCommon.RCStoreTransaction){}[0]

--- a/result/api/result.klib.api
+++ b/result/api/result.klib.api
@@ -5,7 +5,7 @@
 // - Show manifest properties: true
 // - Show declarations: true
 
-// Library unique name: <result>
+// Library unique name: <com.revenuecat.purchases:result>
 final suspend fun (cocoapods.PurchasesHybridCommon/RCPurchases).com.revenuecat.purchases.kmp.result/awaitCustomerInfoResult(com.revenuecat.purchases.kmp/CacheFetchPolicy = ...): kotlin/Result<cocoapods.PurchasesHybridCommon/RCCustomerInfo> // com.revenuecat.purchases.kmp.result/awaitCustomerInfoResult|awaitCustomerInfoResult@cocoapods.PurchasesHybridCommon.RCPurchases(com.revenuecat.purchases.kmp.CacheFetchPolicy){}[0]
 final suspend fun (cocoapods.PurchasesHybridCommon/RCPurchases).com.revenuecat.purchases.kmp.result/awaitGetProductsResult(kotlin.collections/List<kotlin/String>): kotlin/Result<kotlin.collections/List<cocoapods.PurchasesHybridCommon/RCStoreProduct>> // com.revenuecat.purchases.kmp.result/awaitGetProductsResult|awaitGetProductsResult@cocoapods.PurchasesHybridCommon.RCPurchases(kotlin.collections.List<kotlin.String>){}[0]
 final suspend fun (cocoapods.PurchasesHybridCommon/RCPurchases).com.revenuecat.purchases.kmp.result/awaitLogInResult(kotlin/String): kotlin/Result<com.revenuecat.purchases.kmp.ktx/SuccessfulLogin> // com.revenuecat.purchases.kmp.result/awaitLogInResult|awaitLogInResult@cocoapods.PurchasesHybridCommon.RCPurchases(kotlin.String){}[0]


### PR DESCRIPTION
## Changes
- Adds a CircleCI config with a `deploy-snapshot` job that runs for all pushes to `main`. 
- Removes the NmcpPlugin, which I had to use in KobanKat. I had created my Maven Central account after a certain date which meant I could only publish via the [Central Portal](https://central.sonatype.org/register/central-portal/), and `com.vanniktech.maven.publish` did not have support for that at that time. (See https://github.com/vanniktech/gradle-maven-publish-plugin/issues/722.)
- Adjusts the coordinates and POM file to contain RevenueCat info instead of my personal info.
- Updates the klib abi dump, because the group changed (to `com.revenuecat.purchases`). 