### PR TITLE
Adds .aiexclude

### DIFF
--- a/.aiexclude
+++ b/.aiexclude
@@ -1,0 +1,2 @@
+fastlane/.env
+local.properties


### PR DESCRIPTION
Adds `.aiexclude` to exclude files with sensitive info from being accessed by Gemini in Android Studio. More info can be read [here](https://developer.android.com/studio/preview/gemini/aiexclude). 