### PR TITLE
Fixes showInAppMessagesIfNeeded() on iOS

### DIFF
--- a/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/StoreMessageType.kt
+++ b/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/StoreMessageType.kt
@@ -12,13 +12,13 @@ public enum class StoreMessageType {
     BILLING_ISSUES,
 
     /**
-     * App Store only. Generic store messages.
-     */
-    GENERIC,
-
-    /**
      * App Store only. Message shown when there is a price increase in a subscription that requires
      * consent.
      */
     PRICE_INCREASE_CONSENT,
+
+    /**
+     * App Store only. Generic store messages.
+     */
+    GENERIC,
 }

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -311,7 +311,13 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
     public actual fun showInAppMessagesIfNeeded(
         messageTypes: List<StoreMessageType>,
     ): Unit = RCCommonFunctionality.showStoreMessagesForTypes(
-        rawValues = messageTypes.mapTo(mutableSetOf()) { it.ordinal },
+        rawValues = messageTypes.mapTo(mutableSetOf()) { type ->
+            when (type) {
+                StoreMessageType.BILLING_ISSUES -> 0
+                StoreMessageType.PRICE_INCREASE_CONSENT -> 1
+                StoreMessageType.GENERIC -> 2
+            }
+        },
         completion = { }
     )
 


### PR DESCRIPTION
- Fixes conversion of `StoreMessageType` to integer in `showInAppMessagesIfNeeded()` by making it more explicit.
- Aligns `StoreMessageType`'s order with [`StoreMessageType.swift`](https://github.com/RevenueCat/purchases-ios/blob/main/Sources/Support/StoreMessageType.swift) in purchases-ios. 

**Note:** it appears `RCStoreMessageType` is not exposed by PHC which is why the integers are magic numbers now. Something we should look into. 