### PR TITLE
Fixes the release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,19 @@
+aliases:
+  # Uses the same regex as release-tags-job
+  release-tags-workflow: &release-tags-workflow
+    when:
+      and:
+        - matches: { pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+(?!.*-SNAPSHOT).*$", value: << pipeline.git.tag >> }
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+  # Uses the same regex as release-tags-workflow
+  release-tags-job: &release-tags-job
+    filters:
+      tags:
+        only: /^[0-9]+\.[0-9]+\.[0-9]+(?!.*-SNAPSHOT).*$/
+      branches:
+        ignore: /.*/
+
 version: 2.1
 
 orbs:
@@ -259,14 +275,12 @@ workflows:
   # to Maven Central and creates a GitHub release for it. The release train has
   # now completed its journey.
   on-release-tag:
-    when:
-      and:
-        - matches: { pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+(?!.*-SNAPSHOT).*$", value: << pipeline.git.tag >> }
-        - not:
-            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+    <<: *release-tags-workflow
     jobs:
       - publish:
           snapshot: false
           context: maven-central-publishing
+          <<: *release-tags-job
       - create-github-release:
           context: github-bot-public
+          <<: *release-tags-job

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -205,5 +205,8 @@ def publish
   ENV["ORG_GRADLE_PROJECT_mavenCentralPassword"] = ENV["SONATYPE_NEXUS_TOKEN_PASSWORD"]
   ENV["ORG_GRADLE_PROJECT_signingInMemoryKey"] = ENV["SIGNING_GPG_IN_MEMORY"]
   ENV["ORG_GRADLE_PROJECT_signingInMemoryKeyPassword"] = ENV["GPG_SIGNING_KEY_PW_NEW"]
-  gradle(task: "publishAllPublicationsToMavenCentralRepository")
+  gradle(
+    task: "publishAllPublicationsToMavenCentralRepository",
+    flags: "--no-configuration-cache"
+  )
 end


### PR DESCRIPTION
## Fixes the release pipeline
### Adds release tag filters to jobs as well.
As the title says. CircleCI is weird. This bug seems to have existed for a long time where workflows with a tag filter need to have the same filter on jobs as well. 

One of many: https://discuss.circleci.com/t/running-a-workflow-after-tagging-commit/49581. 

Without this change, we get a "[No workflow](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/171)" state from CircleCI.  
  
After this change, [the workflow runs](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/177). 

### Disables configuration cache for the publish task
This is [not supported](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/175/workflows/2c1d41a1-16ad-4b98-af02-6047f9f36763/jobs/251/parallel-runs/0/steps/0-113). 