### PR TITLE
Removes the Compose Compiler Gradle Plugin from :apiTester.

### DIFF
--- a/apiTester/build.gradle.kts
+++ b/apiTester/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.jetbrains.compose)
-    alias(libs.plugins.compose.compiler)
 }
 
 kotlin {


### PR DESCRIPTION
As the title says. This plugin was removed in a previous PR, but was still referenced here. This _should_ make CI go green again. 