### PR TITLE
Fixes viewing revenuecatui Kotlin code in Xcode

### DIFF
--- a/iosApp/iosApp.xcworkspace/contents.xcworkspacedata
+++ b/iosApp/iosApp.xcworkspace/contents.xcworkspacedata
@@ -16,12 +16,12 @@
    </Group>
    <Group
       location = "container:"
-      name = "paywalls">
+      name = "revenuecatui">
       <FileRef
-         location = "group:../paywalls/src/commonMain">
+         location = "group:../revenuecatui/src/commonMain">
       </FileRef>
       <FileRef
-         location = "group:../paywalls/src/iosMain">
+         location = "group:../revenuecatui/src/iosMain">
       </FileRef>
    </Group>
    <FileRef


### PR DESCRIPTION
This `contents.xcworkspacedata` file allows us to see Kotlin code in the Xcode file browser, however it was broken for paywalls code when we renamed the `paywalls` module to `revenuecatui`. This fixes that. 

Visual reference:
![image](https://github.com/RevenueCat/purchases-kmp/assets/29483617/322ca19f-c80e-41a3-9d0e-834e1381590d)
