### PR TITLE
Accept Fastlane Changes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,6 +328,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-23
 
 DEPENDENCIES

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -9,8 +9,7 @@ Make sure you have the latest version of the Xcode command line tools installed:
 xcode-select --install
 ```
 
-For _fastlane_ installation instructions, see [Installing
-_fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
 
 # Available Actions
 
@@ -88,8 +87,7 @@ Creates a GitHub release
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [
-_fastlane_](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 
 More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
 


### PR DESCRIPTION
When trying to kick off the release for 1.0.0-beta.3, fastlane created these changes during the `bump_version_update_changelog_create_pr` task:
- Added `arm64-darwin-21` to `Gemfile.lock`'s `PLATFORMS` section. I'm not sure why it's being added (my machine is running Sonoma, not Monterey). I found it present in the [purchases-ios's Gemfile.lock](https://github.com/RevenueCat/purchases-ios/blob/605861088ac36ce25d55f43bf0bba1cbf8838f8f/Gemfile.lock#L349) as well, so it's probably okay to add it here as well.
- Formatting changes in `fastlane/README.md`: looks like it's combined two lines into one in a few places

Since these changes create changes when compared to the main branch, it causes the `bump_version_update_changelog_create_pr` lane to fail. This PR brings these changes into `main` so that the release can be created.

Here's the command I was using locally to kick off the release:
```bash
GITHUB_PULL_REQUEST_API_TOKEN=REDACTED RC_INTERNAL_FASTLANE_EDITOR=code bundle exec fastlane bump is_prerelease:true next_version:"1.0.0-beta.3" github_rate_limit:10
```