### PR TITLE
Release/1.0.0-beta.3

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -13,9 +13,6 @@ This latest release updates the Android SDK dependency from v7 to [v8](https://g
 This release raises the minimum required OS versions to the following:
 
 - iOS 13.0
-- tvOS 13.0
-- watchOS 6.2
-- macOS 10.15
 - Android: SDK 21 (Android 5.0)
 
 ### In-App Purchase Key Required for StoreKit 2

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,18 +1,36 @@
+## 1.0.0-beta.3 API Changes
+
+This latest release updates the Android SDK dependency from v7 to [v8](https://github.com/RevenueCat/purchases-android/releases/tag/6.0.0) to use BillingClient 7 and updates the iOS SDK dependency from v4 to v5 to use StoreKit 2 by default in the SDK.
+
+### Migration Guides
+
+- For a detailed guide to all of the changes, please see the [KMP V1.0.0-beta.3 Migration Guide](https://github.com/RevenueCat/purchases-kmp/blob/main/migrations/1.0.0-beta.3-MIGRATION.md).
+- See [Android Native - V8 API Migration Guide](https://github.com/RevenueCat/purchases-android/blob/main/migrations/v8-MIGRATION.md) for a more thorough explanation of the Android changes.
+- See [iOS Native - V5 Migration Guide](https://github.com/RevenueCat/purchases-ios/blob/main/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md) for a more thorough explanation of the iOS changes. Notably, this version uses StoreKit 2 to process purchases by default.
+
+### New Minimum OS Versions
+
+This release raises the minimum required OS versions to the following:
+
+- iOS 13.0
+- tvOS 13.0
+- watchOS 6.2
+- macOS 10.15
+- Android: SDK 21 (Android 5.0)
+
+### In-App Purchase Key Required for StoreKit 2
+
+In order to use StoreKit 2, you must configure your In-App Purchase Key in the RevenueCat dashboard. You can find instructions describing how to do this [here](https://www.revenuecat.com/docs/in-app-purchase-key-configuration).
+
 ### Breaking Changes
-* Removes Offerings.getCurrentOfferingForPlacement() (#121) via JayShortway (@JayShortway)
-### Bugfixes
-* Fix iOS crash showing paywall for current offering (#129) via JayShortway (@JayShortway)
-### Dependency Updates
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 11.1.1 (#124) via RevenueCat Git Bot (@RCGitBot)
-  * [Android 7.12.0](https://github.com/RevenueCat/purchases-android/releases/tag/7.12.0)
-  * [iOS 4.43.2](https://github.com/RevenueCat/purchases-ios/releases/tag/4.43.2)
-  * [iOS 4.43.1](https://github.com/RevenueCat/purchases-ios/releases/tag/4.43.1)
+
+- Adopt Latest PHC Version (#139) via Will Taylor (@fire-at-will)
+
 ### Other Changes
-* Improves the error message when the PurchasesInitializer is missing from the merged AndroidManifest.xml. (#130) via JayShortway (@JayShortway)
-* Fixes viewing revenuecatui Kotlin code in Xcode (#127) via JayShortway (@JayShortway)
-* Removes the Compose Compiler Gradle Plugin from :apiTester. (#125) via JayShortway (@JayShortway)
-* Adds missing API tests (#106) via JayShortway (@JayShortway)
-* Publishes API reference only on release. (#122) via JayShortway (@JayShortway)
-* Fixes the release pipeline (#119) via JayShortway (@JayShortway)
-* Adds KobanKat migration guide (#116) via JayShortway (@JayShortway)
-* Updates README.md (#115) via JayShortway (@JayShortway)
+
+- Accept Fastlane Changes (#151) via Will Taylor (@fire-at-will)
+- Adds the git-town config to source control. (#146) via JayShortway (@JayShortway)
+- Appends PHC version to the library version as build metadata (#136) via JayShortway (@JayShortway)
+- Adds required Kotlin test dependencies to :core (#142) via JayShortway (@JayShortway)
+- Temporarily reverts "Remove expect/actual from enums without extra properties (#137)" (#141) via JayShortway (@JayShortway)
+- Remove expect/actual from enums that lack extra properties (#137) via JayShortway (@JayShortway)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## 1.0.0-beta.3
+## 1.0.0-beta.3 API Changes
+
+This latest release updates the Android SDK dependency from v7 to [v8](https://github.com/RevenueCat/purchases-android/releases/tag/6.0.0) to use BillingClient 7 and updates the iOS SDK dependency from v4 to v5 to use StoreKit 2 by default in the SDK.
+
+### Migration Guides
+
+- For a detailed guide to all of the changes, please see the [KMP V1.0.0-beta.3 Migration Guide](https://github.com/RevenueCat/purchases-kmp/blob/main/migrations/1.0.0-beta.3-MIGRATION.md).
+- See [Android Native - V8 API Migration Guide](https://github.com/RevenueCat/purchases-android/blob/main/migrations/v8-MIGRATION.md) for a more thorough explanation of the Android changes.
+- See [iOS Native - V5 Migration Guide](https://github.com/RevenueCat/purchases-ios/blob/main/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md) for a more thorough explanation of the iOS changes. Notably, this version uses StoreKit 2 to process purchases by default.
+
+### New Minimum OS Versions
+
+This release raises the minimum required OS versions to the following:
+
+- iOS 13.0
+- tvOS 13.0
+- watchOS 6.2
+- macOS 10.15
+- Android: SDK 21 (Android 5.0)
+
+### In-App Purchase Key Required for StoreKit 2
+
+In order to use StoreKit 2, you must configure your In-App Purchase Key in the RevenueCat dashboard. You can find instructions describing how to do this [here](https://www.revenuecat.com/docs/in-app-purchase-key-configuration).
+
+### Breaking Changes
+
+- Adopt Latest PHC Version (#139) via Will Taylor (@fire-at-will)
+
+### Other Changes
+
+- Accept Fastlane Changes (#151) via Will Taylor (@fire-at-will)
+- Adds the git-town config to source control. (#146) via JayShortway (@JayShortway)
+- Appends PHC version to the library version as build metadata (#136) via JayShortway (@JayShortway)
+- Adds required Kotlin test dependencies to :core (#142) via JayShortway (@JayShortway)
+- Temporarily reverts "Remove expect/actual from enums without extra properties (#137)" (#141) via JayShortway (@JayShortway)
+- Remove expect/actual from enums that lack extra properties (#137) via JayShortway (@JayShortway)
+
 ## 1.0.0-beta.2
 ### Breaking Changes
 * Removes Offerings.getCurrentOfferingForPlacement() (#121) via JayShortway (@JayShortway)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ This latest release updates the Android SDK dependency from v7 to [v8](https://g
 This release raises the minimum required OS versions to the following:
 
 - iOS 13.0
-- tvOS 13.0
-- watchOS 6.2
-- macOS 10.15
 - Android: SDK 21 (Android 5.0)
 
 ### In-App Purchase Key Required for StoreKit 2

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,4 +1,5 @@
-| Version | iOS version | Android version | Common files version |
-|---------|-------------|-----------------|----------------------|
-| 1.0.0-beta.2 | 4.43.2 | 7.12.0 | 11.1.1 |
-| 1.0.0-beta.1 | 4.43.0 | 7.11.1 | 10.10.0 |
+| Version | iOS version | Android version | Common files version | Play Billing Library version |
+|---------|-------------|-----------------|----------------------|------------------------------|
+| 1.0.0-beta.3 | [5.2.3](https://github.com/RevenueCat/purchases-ios/releases/tag/5.2.3) | [8.4.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.4.0) | [13.0.1](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/13.0.1) | [7.0.0](https://developer.android.com/google/play/billing/release-notes) |
+| 1.0.0-beta.2 | 4.43.2 | 7.12.0 | 11.1.1 | |
+| 1.0.0-beta.1 | 4.43.0 | 7.11.1 | 10.10.0 | |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-targetSdk = "34"
 java = "1.8"
 kotlin = "1.9.23"
 revenuecat-common = "13.0.1"
-revenuecat-kmp = "1.0.0-SNAPSHOT"
+revenuecat-kmp = "1.0.0-beta.3"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/migrations/1.0.0-beta.3-MIGRATION.md
+++ b/migrations/1.0.0-beta.3-MIGRATION.md
@@ -12,9 +12,6 @@ This latest release updates the Android SDK dependency from v7 to [v8](https://g
 This release raises the minimum required OS versions to the following:
 
 - iOS 13.0
-- tvOS 13.0
-- watchOS 6.2
-- macOS 10.15
 - Android: SDK 21 (Android 5.0)
 
 ### In-App Purchase Key Required for StoreKit 2
@@ -45,18 +42,6 @@ val configuration = PurchasesConfiguration(apiKey = {YOUR_API_KEY}) {
 Purchases.configure(configuration)
 ```
 
-#### ⚠️ Observing Purchases Completed by Your App on macOS
-
-By default, when purchases are completed by your app using StoreKit 2 on macOS, the SDK does not detect a user's purchase until after the user foregrounds the app after the purchase has been made. If you'd like RevenueCat to immediately detect the user's purchase, call `Purchases.recordPurchase(productID)` for any new purchases, like so:
-
-```kotlin
-Purchases.sharedInstance.recordPurchase(
-    productID = {PRODUCT_ID_OF_RECENTLY_PURCHASED_PRODUCT},
-    onError = { error ->  },
-    onSuccess = { storeTransaction ->  }
-)
-```
-
 #### Observing Purchases Completed by Your App with StoreKit 1
 
 If purchases are completed by your app using StoreKit 1, you will need to explicitly configure the SDK to use StoreKit 1:
@@ -77,4 +62,4 @@ The getter and setter on `Purchases.sharedInstance.purchasesAreCompletedBy` has 
 
 ### Reporting undocumented issues:
 
-Feel free to file an issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-flutter/issues/new/).
+Feel free to file an issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-kmp/issues/new/choose).


### PR DESCRIPTION
## 1.0.0-beta.3 API Changes

This latest release updates the Android SDK dependency from v7 to [v8](https://github.com/RevenueCat/purchases-android/releases/tag/6.0.0) to use BillingClient 7 and updates the iOS SDK dependency from v4 to v5 to use StoreKit 2 by default in the SDK.

### Migration Guides

- For a detailed guide to all of the changes, please see the [KMP V1.0.0-beta.3 Migration Guide](https://github.com/RevenueCat/purchases-kmp/blob/main/migrations/1.0.0-beta.3-MIGRATION.md).
- See [Android Native - V8 API Migration Guide](https://github.com/RevenueCat/purchases-android/blob/main/migrations/v8-MIGRATION.md) for a more thorough explanation of the Android changes.
- See [iOS Native - V5 Migration Guide](https://github.com/RevenueCat/purchases-ios/blob/main/Sources/DocCDocumentation/DocCDocumentation.docc/V5_API_Migration_guide.md) for a more thorough explanation of the iOS changes. Notably, this version uses StoreKit 2 to process purchases by default.

### New Minimum OS Versions

This release raises the minimum required OS versions to the following:

- iOS 13.0
- tvOS 13.0
- watchOS 6.2
- macOS 10.15
- Android: SDK 21 (Android 5.0)

### In-App Purchase Key Required for StoreKit 2

In order to use StoreKit 2, you must configure your In-App Purchase Key in the RevenueCat dashboard. You can find instructions describing how to do this [here](https://www.revenuecat.com/docs/in-app-purchase-key-configuration).

### Breaking Changes

- Adopt Latest PHC Version (#139) via Will Taylor (@fire-at-will)

### Other Changes

- Accept Fastlane Changes (#151) via Will Taylor (@fire-at-will)
- Adds the git-town config to source control. (#146) via JayShortway (@JayShortway)
- Appends PHC version to the library version as build metadata (#136) via JayShortway (@JayShortway)
- Adds required Kotlin test dependencies to :core (#142) via JayShortway (@JayShortway)
- Temporarily reverts "Remove expect/actual from enums without extra properties (#137)" (#141) via JayShortway (@JayShortway)
- Remove expect/actual from enums that lack extra properties (#137) via JayShortway (@JayShortway)
