### PR TITLE
Remove mentions of non-iOS Apple targets in 1.0.0-beta.3-MIGRATION.md

### DIFF
--- a/migrations/1.0.0-beta.3-MIGRATION.md
+++ b/migrations/1.0.0-beta.3-MIGRATION.md
@@ -12,9 +12,6 @@ This latest release updates the Android SDK dependency from v7 to [v8](https://g
 This release raises the minimum required OS versions to the following:
 
 - iOS 13.0
-- tvOS 13.0
-- watchOS 6.2
-- macOS 10.15
 - Android: SDK 21 (Android 5.0)
 
 ### In-App Purchase Key Required for StoreKit 2
@@ -43,18 +40,6 @@ val configuration = PurchasesConfiguration(apiKey = {YOUR_API_KEY}) {
     purchasesAreCompletedBy = PurchasesAreCompletedBy.MyApp(StoreKitVersion.STOREKIT_2)
 }
 Purchases.configure(configuration)
-```
-
-#### ⚠️ Observing Purchases Completed by Your App on macOS
-
-By default, when purchases are completed by your app using StoreKit 2 on macOS, the SDK does not detect a user's purchase until after the user foregrounds the app after the purchase has been made. If you'd like RevenueCat to immediately detect the user's purchase, call `Purchases.recordPurchase(productID)` for any new purchases, like so:
-
-```kotlin
-Purchases.sharedInstance.recordPurchase(
-    productID = {PRODUCT_ID_OF_RECENTLY_PURCHASED_PRODUCT},
-    onError = { error ->  },
-    onSuccess = { storeTransaction ->  }
-)
 ```
 
 #### Observing Purchases Completed by Your App with StoreKit 1


### PR DESCRIPTION
As the title says. Apologies for missing this earlier. As of now, the only Apple target we support is iOS. We're looking to expand that in the future, but for now it will be confusing to mention these targets in the migration guide. 