### PR TITLE
Wraps the native Android LogHandler if necessary

### DIFF
--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
@@ -8,7 +8,6 @@ import com.revenuecat.purchases.getProductsWith
 import com.revenuecat.purchases.kmp.di.AndroidProvider
 import com.revenuecat.purchases.kmp.di.requireActivity
 import com.revenuecat.purchases.kmp.di.requireApplication
-import com.revenuecat.purchases.kmp.mappings.DefaultLogHandler
 import com.revenuecat.purchases.kmp.mappings.toAndroidBillingFeature
 import com.revenuecat.purchases.kmp.mappings.toAndroidCacheFetchPolicy
 import com.revenuecat.purchases.kmp.mappings.toAndroidGoogleReplacementMode
@@ -93,8 +92,6 @@ public actual class Purchases private constructor(private val androidPurchases: 
 
         @JvmStatic
         public actual fun configure(configuration: PurchasesConfiguration): Purchases {
-            // Sets the log handler to the default before configuring the SDK.
-            logHandler = DefaultLogHandler()
             with(configuration) {
                 // Using the common configure() call allows us to pass PlatformInfo.
                 commonConfigure(

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -7,7 +7,6 @@ import cocoapods.PurchasesHybridCommon.recordPurchaseForProductID
 import cocoapods.PurchasesHybridCommon.setAirshipChannelID
 import cocoapods.PurchasesHybridCommon.setOnesignalUserID
 import cocoapods.PurchasesHybridCommon.showStoreMessagesForTypes
-import com.revenuecat.purchases.kmp.mappings.DefaultLogHandler
 import com.revenuecat.purchases.kmp.mappings.buildStoreTransaction
 import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
 import com.revenuecat.purchases.kmp.mappings.toHybridString
@@ -17,6 +16,7 @@ import com.revenuecat.purchases.kmp.mappings.toIosPackage
 import com.revenuecat.purchases.kmp.mappings.toIosPromotionalOffer
 import com.revenuecat.purchases.kmp.mappings.toIosStoreProduct
 import com.revenuecat.purchases.kmp.mappings.toIosStoreProductDiscount
+import com.revenuecat.purchases.kmp.mappings.toLogHandler
 import com.revenuecat.purchases.kmp.mappings.toLogLevel
 import com.revenuecat.purchases.kmp.mappings.toOfferings
 import com.revenuecat.purchases.kmp.mappings.toPromotionalOffer
@@ -48,11 +48,9 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
             get() = IosPurchases.logLevel().toLogLevel()
             set(value) = IosPurchases.setLogLevel(value.toRcLogLevel())
 
-        private var _logHandler: LogHandler = DefaultLogHandler()
         public actual var logHandler: LogHandler
-            get() = _logHandler
+            get() = IosPurchases.logHandler().toLogHandler()
             set(value) {
-                _logHandler = value
                 IosPurchases.setLogHandler(value.toIosLogHandler())
             }
 
@@ -75,8 +73,6 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
             configuration: PurchasesConfiguration
         ): Purchases {
             checkCommonVersion()
-            // This sets the log handler to the default one right before configuring the SDK.
-            logHandler = _logHandler
 
             return with(configuration) {
                 IosPurchases.configureWithAPIKey(

--- a/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/LogHandler.android.kt
+++ b/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/LogHandler.android.kt
@@ -1,37 +1,21 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import android.util.Log
 import com.revenuecat.purchases.kmp.LogHandler
-import com.revenuecat.purchases.LogHandler as NativeAndroidLogHandler
+import com.revenuecat.purchases.LogHandler as AndroidLogHandler
 
-public fun NativeAndroidLogHandler.toLogHandler(): LogHandler =
-    (this as LogHandlerWrapper).wrapped
-
-public fun LogHandler.toAndroidLogHandler(): NativeAndroidLogHandler = LogHandlerWrapper(this)
-
-public class DefaultLogHandler: LogHandler {
-    override fun d(tag: String, msg: String) {
-        Log.d(tag, msg)
+public fun AndroidLogHandler.toLogHandler(): LogHandler =
+    when (this) {
+        is LogHandlerWrapper -> wrapped
+        else -> AndroidLogHandlerWrapper(this)
     }
 
-    override fun e(tag: String, msg: String, throwable: Throwable?) {
-        Log.e(tag, msg, throwable)
+public fun LogHandler.toAndroidLogHandler(): AndroidLogHandler =
+    when (this) {
+        is AndroidLogHandlerWrapper -> wrapped
+        else -> LogHandlerWrapper(this)
     }
 
-    override fun i(tag: String, msg: String) {
-        Log.i(tag, msg)
-    }
-
-    override fun v(tag: String, msg: String) {
-        Log.v(tag, msg)
-    }
-
-    override fun w(tag: String, msg: String) {
-        Log.w(tag, msg)
-    }
-}
-
-private class LogHandlerWrapper(val wrapped: LogHandler) : NativeAndroidLogHandler {
+private class LogHandlerWrapper(val wrapped: LogHandler) : AndroidLogHandler {
     override fun d(tag: String, msg: String) {
         wrapped.d(tag, msg)
     }
@@ -51,5 +35,26 @@ private class LogHandlerWrapper(val wrapped: LogHandler) : NativeAndroidLogHandl
     override fun w(tag: String, msg: String) {
         wrapped.w(tag, msg)
     }
+}
 
+private class AndroidLogHandlerWrapper(val wrapped: AndroidLogHandler) : LogHandler {
+    override fun d(tag: String, msg: String) {
+        wrapped.d(tag, msg)
+    }
+
+    override fun e(tag: String, msg: String, throwable: Throwable?) {
+        wrapped.e(tag, msg, throwable)
+    }
+
+    override fun i(tag: String, msg: String) {
+        wrapped.i(tag, msg)
+    }
+
+    override fun v(tag: String, msg: String) {
+        wrapped.v(tag, msg)
+    }
+
+    override fun w(tag: String, msg: String) {
+        wrapped.w(tag, msg)
+    }
 }


### PR DESCRIPTION
Removes the need for `DefaultLogHandler` by wrapping the native `AndroidLogHandler` if no `LogHandler` has been set yet.