### PR TITLE
Converts the last few data classes to regular classes.

### DIFF
--- a/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/ktx/Coroutines.kt
+++ b/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/ktx/Coroutines.kt
@@ -21,33 +21,33 @@ import kotlin.coroutines.suspendCoroutine
 /**
  * The result of a successful purchase operation. Used in coroutines.
  */
-public data class SuccessfulPurchase(
+public class SuccessfulPurchase(
     /**
      * The [StoreTransaction] for this purchase.
      */
-    val storeTransaction: StoreTransaction,
+    public val storeTransaction: StoreTransaction,
 
     /**
      * The updated [CustomerInfo] for this user after the purchase has been synced with
      * RevenueCat's servers.
      */
-    val customerInfo: CustomerInfo,
+    public val customerInfo: CustomerInfo,
 )
 
 /**
  * The result of a successful login operation. Used in coroutines.
  */
-public data class SuccessfulLogin(
+public class SuccessfulLogin(
     /**
      * The [CustomerInfo] associated with the logged in user.
      */
-    val customerInfo: CustomerInfo,
+    public val customerInfo: CustomerInfo,
 
     /**
      * true if a new user has been registered in the backend,
      * false if the user had already been registered.
      */
-    val created: Boolean,
+    public val created: Boolean,
 )
 
 /**

--- a/either/src/commonMain/kotlin/com/revenuecat/purchases/kmp/either/Either.kt
+++ b/either/src/commonMain/kotlin/com/revenuecat/purchases/kmp/either/Either.kt
@@ -25,15 +25,15 @@ import kotlin.coroutines.suspendCoroutine
 /**
  * The result of a failed purchase operation. Used by suspending functions returning [Either].
  */
-public data class FailedPurchase(
+public class FailedPurchase internal constructor(
     /**
      * The error that occurred.
      */
-    val error: PurchasesError,
+    public val error: PurchasesError,
     /**
      * Whether the user cancelled the transaction.
      */
-    val userCancelled: Boolean,
+    public val userCancelled: Boolean,
 )
 
 /**

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/PurchasesAreCompletedBy.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/PurchasesAreCompletedBy.kt
@@ -24,5 +24,5 @@ public sealed interface PurchasesAreCompletedBy {
      * If your app is Android-only, you may provide any value since it is ignored in the native
      * Android SDK.
      */
-    public data class MyApp(val storeKitVersion: StoreKitVersion) : PurchasesAreCompletedBy
+    public class MyApp(public val storeKitVersion: StoreKitVersion) : PurchasesAreCompletedBy
 }


### PR DESCRIPTION
As the title says. Unfortunately `SuccessfulPurchase` and `SuccessfulLogin` needed to keep their public constructors, because they are constructed in `:result` and `:either`. It's not ideal, but not terrible either imo. 