### PR TITLE
Fixes a PaywallListener crash

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/App.kt
@@ -29,6 +29,7 @@ fun App() {
                 .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            val loggingListener = rememberLoggingPaywallListener()
             var screen by remember { mutableStateOf<Screen>(Screen.Main) }
 
             when (val currentScreen = screen) {
@@ -45,6 +46,7 @@ fun App() {
                     val options = PaywallOptions(dismissRequest = { screen = Screen.Main }) {
                         offering = currentScreen.offering
                         shouldDisplayDismissButton = true
+                        listener = loggingListener
                     }
                     Paywall(options)
                 }
@@ -53,6 +55,7 @@ fun App() {
                     val options = PaywallOptions(dismissRequest = { screen = Screen.Main }) {
                         offering = currentScreen.offering
                         shouldDisplayDismissButton = true
+                        listener = loggingListener
                     }
                     PaywallFooter(options) { contentPadding ->
                         CustomPaywallContent(

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/rememberLoggingPaywallListener.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/rememberLoggingPaywallListener.kt
@@ -1,0 +1,52 @@
+package com.revenuecat.purchases.kmp.sample
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.revenuecat.purchases.kmp.CustomerInfo
+import com.revenuecat.purchases.kmp.Package
+import com.revenuecat.purchases.kmp.PurchasesError
+import com.revenuecat.purchases.kmp.models.StoreTransaction
+import com.revenuecat.purchases.kmp.ui.revenuecatui.PaywallListener
+
+@Composable
+internal fun rememberLoggingPaywallListener() = remember {
+    object : PaywallListener {
+        override fun onPurchaseStarted(rcPackage: Package) {
+            super.onPurchaseStarted(rcPackage)
+            println("onPurchaseStarted: $rcPackage")
+        }
+
+        override fun onPurchaseCompleted(
+            customerInfo: CustomerInfo,
+            storeTransaction: StoreTransaction
+        ) {
+            super.onPurchaseCompleted(customerInfo, storeTransaction)
+            println("onPurchaseCompleted: $customerInfo, $storeTransaction")
+        }
+
+        override fun onPurchaseError(error: PurchasesError) {
+            super.onPurchaseError(error)
+            println("onPurchaseError: $error")
+        }
+
+        override fun onPurchaseCancelled() {
+            super.onPurchaseCancelled()
+            println("onPurchaseCancelled")
+        }
+
+        override fun onRestoreStarted() {
+            super.onRestoreStarted()
+            println("onRestoreStarted")
+        }
+
+        override fun onRestoreCompleted(customerInfo: CustomerInfo) {
+            super.onRestoreCompleted(customerInfo)
+            println("onRestoreCompleted: $customerInfo")
+        }
+
+        override fun onRestoreError(error: PurchasesError) {
+            super.onRestoreError(error)
+            println("onRestoreError: $error")
+        }
+    }
+}

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -1,20 +1,24 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
+// Not sure why we have 2 Kotlin mappings to the same ObjC classes.
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewControllerDelegateProtocol
-import com.revenuecat.purchases.kmp.CustomerInfo
-import com.revenuecat.purchases.kmp.Package
-import com.revenuecat.purchases.kmp.models.StoreTransaction
+import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
+import com.revenuecat.purchases.kmp.mappings.toPackage
 import com.revenuecat.purchases.kmp.mappings.toPurchasesErrorOrThrow
+import com.revenuecat.purchases.kmp.mappings.toStoreTransaction
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
-import objcnames.classes.RCCustomerInfo
-import objcnames.classes.RCPackage
-import objcnames.classes.RCStoreTransaction
 import platform.CoreGraphics.CGSize
 import platform.Foundation.NSError
 import platform.darwin.NSObject
+import cocoapods.PurchasesHybridCommon.RCCustomerInfo as PhcCustomerInfo
+import cocoapods.PurchasesHybridCommon.RCPackage as PhcPackage
+import cocoapods.PurchasesHybridCommon.RCStoreTransaction as PhcStoreTransaction
+import objcnames.classes.RCCustomerInfo as ObjcNamesCustomerInfo
+import objcnames.classes.RCPackage as ObjcNamesPackage
+import objcnames.classes.RCStoreTransaction as ObjcNamesStoreTransaction
 
 internal class IosPaywallDelegate(
     private val listener: PaywallListener?,
@@ -25,20 +29,22 @@ internal class IosPaywallDelegate(
     @Suppress("CAST_NEVER_SUCCEEDS")
     override fun paywallViewController(
         controller: RCPaywallViewController,
-        didStartPurchaseWithPackage: RCPackage
+        didStartPurchaseWithPackage: ObjcNamesPackage
     ) {
-        listener?.onPurchaseStarted(didStartPurchaseWithPackage as Package)
+        listener?.onPurchaseStarted(
+            (didStartPurchaseWithPackage as PhcPackage).toPackage()
+        )
     }
 
     @Suppress("CAST_NEVER_SUCCEEDS")
     override fun paywallViewController(
         controller: RCPaywallViewController,
-        didFinishPurchasingWithCustomerInfo: RCCustomerInfo,
-        transaction: RCStoreTransaction?
+        didFinishPurchasingWithCustomerInfo: ObjcNamesCustomerInfo,
+        transaction: ObjcNamesStoreTransaction?
     ) {
         listener?.onPurchaseCompleted(
-            didFinishPurchasingWithCustomerInfo as CustomerInfo,
-            transaction as StoreTransaction
+            (didFinishPurchasingWithCustomerInfo as PhcCustomerInfo).toCustomerInfo(),
+            (transaction as PhcStoreTransaction).toStoreTransaction()
         )
     }
 
@@ -61,9 +67,11 @@ internal class IosPaywallDelegate(
     @Suppress("CAST_NEVER_SUCCEEDS", "PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     override fun paywallViewController(
         controller: RCPaywallViewController,
-        didFinishRestoringWithCustomerInfo: RCCustomerInfo
+        didFinishRestoringWithCustomerInfo: ObjcNamesCustomerInfo
     ) {
-        listener?.onRestoreCompleted(didFinishRestoringWithCustomerInfo as CustomerInfo)
+        listener?.onRestoreCompleted(
+            (didFinishRestoringWithCustomerInfo as PhcCustomerInfo).toCustomerInfo()
+        )
     }
 
     @Suppress("CONFLICTING_OVERLOADS", "PARAMETER_NAME_CHANGED_ON_OVERRIDE")

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
-// Not sure why we have 2 Kotlin mappings to the same ObjC classes.
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewControllerDelegateProtocol
 import com.revenuecat.purchases.kmp.mappings.toCustomerInfo


### PR DESCRIPTION
As the title says. Also added a listener to the tester app, and was able to reproduce it with that. Verified no more crashes on both Android and iOS.

## Cause
We were unsafely casting, which worked fine before when everything was a type alias. That's no longer the case. `StoreTransaction` was already converted away from a type alias in `1.0.0-beta.3`, and we made it "worse" on `main` by converting the rest. 

## Fix
For some weird reason we have double Kotlin mappings for the same underlying ObjC class. For now, I'm casting one to the other (which works because it's the same thing), and then calling our mapper function. 

I also checked some other casts we do, and they _seem_ okay so far. 

Closes #168 