### PR TITLE
Adds v1 migration guide

### DIFF
--- a/migrations/1.0.0-MIGRATION.md
+++ b/migrations/1.0.0-MIGRATION.md
@@ -3,6 +3,10 @@
 The RevenueCat SDK for Kotlin Multiplatform has reached v1! Here's everything you need to know if
 you're coming from a previous version.
 
+## In-App Purchase Key Required for StoreKit 2
+> [!CAUTION]
+> You **must** configure your [In-App Purchase Key](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration) in the RevenueCat dashboard. **Purchases will fail if the key is not configured**. This is a new requirement for all RevenueCat SDKs.
+
 ## New versioning scheme
 
 Since purchases-kmp depends on a separate iOS framework (`PurchasesHybridCommon[UI]`) that needs to

--- a/migrations/1.0.0-MIGRATION.md
+++ b/migrations/1.0.0-MIGRATION.md
@@ -1,22 +1,24 @@
 # 1.0.0 Migration Guide
 
-The RevenueCat SDK for Kotlin Multiplatform has reached v1! Here's everything you need to know if
-you're coming from a previous version.
+The RevenueCat SDK for Kotlin Multiplatform has reached v1! Here's everything you need to know if you're coming from a previous version.
 
 ## In-App Purchase Key Required for StoreKit 2
 > [!CAUTION]
 > You **must** configure your [In-App Purchase Key](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration) in the RevenueCat dashboard. **Purchases will fail if the key is not configured**. This is a new requirement for all RevenueCat SDKs.
 
 ## New versioning scheme
-
 Since purchases-kmp depends on a separate iOS framework (`PurchasesHybridCommon[UI]`) that needs to
 be linked to your iOS project manually, the versioning scheme was changed to make that a bit easer.
 The new versioning scheme is in the form `X+Y`, where:
-
 * `X` is the purchases-kmp version.
 * `Y` is the `PurchasesHybridCommon[UI]` version.
 
-## Reporting undocumented issues:
+## Platform SDKs no longer public
+The underlying Android and iOS SDKs are no longer public. If you were importing platform types in your `androidMain` and/or `iosMain` source sets, you'll have to switch to the common types. The common types have `.kmp.` in their package name. If you were only using purchases-kmp in your common source set, this does not affect you.
 
+## Fewer extensions
+The number of extension functions and properties is drastically reduced. Previously, almost every member of the platform types was an extension in purchases-kmp. These are now all members in purchases-kmp too. Since extensions are imported separately, these imports have to be removed. You can do this automatically in Android Studio by pressing Ctrl + Option + O for a single file, or right click on any folder and click Optimize Imports.  
+
+## Reporting undocumented issues:
 Feel free to file an
 issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-kmp/issues/new/).

--- a/migrations/1.0.0-MIGRATION.md
+++ b/migrations/1.0.0-MIGRATION.md
@@ -1,6 +1,8 @@
 # 1.0.0 Migration Guide
-
-The RevenueCat SDK for Kotlin Multiplatform has reached v1! Here's everything you need to know if you're coming from a previous version.
+The RevenueCat SDK for Kotlin Multiplatform has reached v1! Here's everything you need to know if you're coming from a previous version. 
+- If you're coming from KobanKat, start [here](KobanKat-MIGRATION.md).
+- If you're coming from purchases-kmp `1.0.0-beta.1` or `1.0.0-beta.2`, start [here](1.0.0-beta.3-MIGRATION.md).
+- If you're coming from purchases-kmp `1.0.0-beta.3`, keep reading.
 
 ## In-App Purchase Key Required for StoreKit 2
 > [!CAUTION]

--- a/migrations/1.0.0-MIGRATION.md
+++ b/migrations/1.0.0-MIGRATION.md
@@ -1,0 +1,18 @@
+# 1.0.0 Migration Guide
+
+The RevenueCat SDK for Kotlin Multiplatform has reached v1! Here's everything you need to know if
+you're coming from a previous version.
+
+## New versioning scheme
+
+Since purchases-kmp depends on a separate iOS framework (`PurchasesHybridCommon[UI]`) that needs to
+be linked to your iOS project manually, the versioning scheme was changed to make that a bit easer.
+The new versioning scheme is in the form `X+Y`, where:
+
+* `X` is the purchases-kmp version.
+* `Y` is the `PurchasesHybridCommon[UI]` version.
+
+## Reporting undocumented issues:
+
+Feel free to file an
+issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-kmp/issues/new/).

--- a/migrations/1.0.0-beta.3-MIGRATION.md
+++ b/migrations/1.0.0-beta.3-MIGRATION.md
@@ -2,6 +2,10 @@
 
 This latest release updates the Android SDK dependency from v7 to [v8](https://github.com/RevenueCat/purchases-android/releases/tag/6.0.0) to use BillingClient 7 and updates the iOS SDK dependency from v4 to v5 to use StoreKit 2 by default in the SDK.
 
+### In-App Purchase Key Required for StoreKit 2
+> [!CAUTION]
+> You **must** configure your [In-App Purchase Key](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration) in the RevenueCat dashboard. **Purchases will fail if the key is not configured**. This is a new requirement for all RevenueCat SDKs.
+
 ### Migration Guides
 
 - See [Android Native - V8 API Migration Guide](https://github.com/RevenueCat/purchases-android/blob/main/migrations/v8-MIGRATION.md) for a more thorough explanation of the Android changes.
@@ -13,10 +17,6 @@ This release raises the minimum required OS versions to the following:
 
 - iOS 13.0
 - Android: SDK 21 (Android 5.0)
-
-### In-App Purchase Key Required for StoreKit 2
-
-In order to use StoreKit 2, you must configure your In-App Purchase Key in the RevenueCat dashboard. You can find instructions describing how to do this [here](https://www.revenuecat.com/docs/in-app-purchase-key-configuration).
 
 ### Specifying StoreKit version with `storeKitVersion` (iOS Only)
 

--- a/migrations/1.0.0-beta.3-MIGRATION.md
+++ b/migrations/1.0.0-beta.3-MIGRATION.md
@@ -1,6 +1,7 @@
 ## 1.0.0-beta.3 API Changes
+This latest release updates the Android SDK dependency from v7 to [v8](https://github.com/RevenueCat/purchases-android/releases/tag/8.0.0) to use BillingClient 7 and updates the iOS SDK dependency from v4 to [v5](https://github.com/RevenueCat/purchases-ios/releases/tag/5.0.0) to use StoreKit 2 by default in the SDK.
 
-This latest release updates the Android SDK dependency from v7 to [v8](https://github.com/RevenueCat/purchases-android/releases/tag/6.0.0) to use BillingClient 7 and updates the iOS SDK dependency from v4 to v5 to use StoreKit 2 by default in the SDK.
+If you're coming from KobanKat, make sure you follow the [KobanKat migration guide](KobanKat-MIGRATION.md) first.
 
 ### In-App Purchase Key Required for StoreKit 2
 > [!CAUTION]

--- a/migrations/1.0.0-beta.3-MIGRATION.md
+++ b/migrations/1.0.0-beta.3-MIGRATION.md
@@ -60,6 +60,11 @@ The getter and setter on `Purchases.sharedInstance.purchasesAreCompletedBy` has 
 - `PurchasesConfiguration.pendingTransactionsForPrepaidPlansEnabled`: Enable this setting if you want to allow pending purchases for prepaid subscriptions (only supported in Google Play). Note that entitlements are not granted until payment is done. Default is disabled.
 - `SubscriptionOption.InstallmentsInfo`: Type containing information of installment subscriptions. Currently only supported in Google Play.
 
+## Next steps
+
+If you're migrating to the stable `1.0.0` or newer, make sure to follow
+the [`1.0.0`](1.0.0-MIGRATION.md) migration guide next.
+
 ### Reporting undocumented issues:
 
 Feel free to file an issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-kmp/issues/new/choose).


### PR DESCRIPTION
As the title says. Also did some minor updates to the `1.0.0-beta.3` migration guide. Please let me know if you think of something else that should be added! 