### PR TITLE
Greatly simplifies how Price.amountMicros is determined on iOS.

### DIFF
--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -179,7 +179,8 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         withProduct = storeProduct.toIosStoreProduct(),
     ) { offer, error ->
         if (error != null) onError(error.toPurchasesErrorOrThrow())
-        else onSuccess(offer?.toPromotionalOffer(storeProduct.toIosStoreProduct().priceFormatter())
+        else onSuccess(
+            offer?.toPromotionalOffer()
             ?: error("Expected a non-null RCPromotionalOffer"))
     }
 

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - PurchasesHybridCommon (13.0.1):
-    - RevenueCat (= 5.2.3)
-  - PurchasesHybridCommonUI (13.0.1):
-    - PurchasesHybridCommon (= 13.0.1)
-    - RevenueCatUI (= 5.2.3)
-  - RevenueCat (5.2.3)
-  - RevenueCatUI (5.2.3):
-    - RevenueCat (= 5.2.3)
+  - PurchasesHybridCommon (13.2.0):
+    - RevenueCat (= 5.3.1)
+  - PurchasesHybridCommonUI (13.2.0):
+    - PurchasesHybridCommon (= 13.2.0)
+    - RevenueCatUI (= 5.3.1)
+  - RevenueCat (5.3.1)
+  - RevenueCatUI (5.3.1):
+    - RevenueCat (= 5.3.1)
 
 DEPENDENCIES:
-  - PurchasesHybridCommon (= 13.0.1)
-  - PurchasesHybridCommonUI (= 13.0.1)
+  - PurchasesHybridCommon (= 13.2.0)
+  - PurchasesHybridCommonUI (= 13.2.0)
 
 SPEC REPOS:
   trunk:
@@ -20,11 +20,11 @@ SPEC REPOS:
     - RevenueCatUI
 
 SPEC CHECKSUMS:
-  PurchasesHybridCommon: 6e5772e574ce345922c42f31403cf72a0ba762bf
-  PurchasesHybridCommonUI: 015291e795d694c83ab1fd35caf3716c7c1f7cdf
-  RevenueCat: 86e4486345a6f7740fecb1eeff91eeff8708eee1
-  RevenueCatUI: c19388c5f35ef5beea1b9b7a2593479f12303dc6
+  PurchasesHybridCommon: 20acf98303a9593f5d56b449459dcf16ea581a99
+  PurchasesHybridCommonUI: fc8fa6ad78cfcdb6d82a8a865a8ae8b78724df53
+  RevenueCat: b2d2555cbb1f4116d341af4c5f82269c8e4e499a
+  RevenueCatUI: 59b63f64505eac217af31f596e1ce3583734bba6
 
-PODFILE CHECKSUM: 6d9a95ffe52c861fbf2a9732430df4145d15f979
+PODFILE CHECKSUM: 765478420b42264728e182ac4d530b13d5d77b49
 
 COCOAPODS: 1.15.2

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.ios.kt
@@ -2,44 +2,25 @@ package com.revenuecat.purchases.kmp.mappings
 
 import cocoapods.PurchasesHybridCommon.RCStoreProduct
 import cocoapods.PurchasesHybridCommon.RCStoreProductDiscount
+import cocoapods.PurchasesHybridCommon.price
 import com.revenuecat.purchases.kmp.models.Price
-import platform.Foundation.NSDecimalNumber
-import platform.Foundation.NSNumberFormatter
 
 internal fun RCStoreProduct.toPrice(): Price =
-    localizedPriceString().let { localizedPrice ->
-        Price(
-            formatted = localizedPrice,
-            amountMicros = priceFormatter().amountDecimalOrDefault(
-                localizedPrice = localizedPrice,
-                defaultValue = "0.0"
-            ).decimalNumberByMultiplyingByPowerOf10(6).longValue,
-            currencyCode = currencyCodeOrUsd(),
-        )
-    }
+    Price(
+        formatted = localizedPriceString(),
+        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longValue,
+        currencyCode = currencyCodeOrUsd(),
+    )
 
 internal fun RCStoreProduct.currencyCodeOrUsd(): String =
     currencyCode() ?: priceFormatter()?.currencyCode() ?: "USD" // FIXME revisit
 
-internal fun RCStoreProductDiscount.toPrice(formatter: NSNumberFormatter?): Price =
-    localizedPriceString().let { localizedPrice ->
-        Price(
-            formatted = localizedPrice,
-            amountMicros = formatter.amountDecimalOrDefault(
-                localizedPrice = localizedPrice,
-                defaultValue = "0.0"
-            ).decimalNumberByMultiplyingByPowerOf10(6).longValue,
-            currencyCode = currencyCodeOrUsd(),
-        )
-    }
+internal fun RCStoreProductDiscount.toPrice(): Price =
+    Price(
+        formatted = localizedPriceString(),
+        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longValue,
+        currencyCode = currencyCodeOrUsd(),
+    )
 
 internal fun RCStoreProductDiscount.currencyCodeOrUsd(): String =
     currencyCode() ?: "USD" // FIXME revisit
-
-private fun NSNumberFormatter?.amountDecimalOrDefault(
-    localizedPrice: String,
-    defaultValue: String
-): NSDecimalNumber =
-    this?.numberFromString(localizedPrice)
-        ?.let { NSDecimalNumber.decimalNumberWithString(it.stringValue) }
-        ?: NSDecimalNumber.decimalNumberWithString(defaultValue)

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.ios.kt
@@ -2,13 +2,13 @@ package com.revenuecat.purchases.kmp.mappings
 
 import cocoapods.PurchasesHybridCommon.RCStoreProduct
 import cocoapods.PurchasesHybridCommon.RCStoreProductDiscount
-import cocoapods.PurchasesHybridCommon.price
+import cocoapods.PurchasesHybridCommon.priceAmount
 import com.revenuecat.purchases.kmp.models.Price
 
 internal fun RCStoreProduct.toPrice(): Price =
     Price(
         formatted = localizedPriceString(),
-        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longValue,
+        amountMicros = priceAmount().decimalNumberByMultiplyingByPowerOf10(6).longValue,
         currencyCode = currencyCodeOrUsd(),
     )
 
@@ -18,7 +18,7 @@ internal fun RCStoreProduct.currencyCodeOrUsd(): String =
 internal fun RCStoreProductDiscount.toPrice(): Price =
     Price(
         formatted = localizedPriceString(),
-        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longValue,
+        amountMicros = priceAmount().decimalNumberByMultiplyingByPowerOf10(6).longValue,
         currencyCode = currencyCodeOrUsd(),
     )
 

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PromotionalOffer.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PromotionalOffer.ios.kt
@@ -2,15 +2,14 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.PromotionalOffer
 import com.revenuecat.purchases.kmp.models.StoreProductDiscount
-import platform.Foundation.NSNumberFormatter
 import cocoapods.PurchasesHybridCommon.RCPromotionalOffer as NativeIosPromotionalOffer
 
-public fun NativeIosPromotionalOffer.toPromotionalOffer(priceFormatter: NSNumberFormatter?): PromotionalOffer =
-    IosPromotionalOffer(this, priceFormatter)
+public fun NativeIosPromotionalOffer.toPromotionalOffer(): PromotionalOffer =
+    IosPromotionalOffer(this)
 
 public fun PromotionalOffer.toIosPromotionalOffer(): NativeIosPromotionalOffer = (this as IosPromotionalOffer).wrapped
 
-private class IosPromotionalOffer(val wrapped: NativeIosPromotionalOffer, priceFormatter: NSNumberFormatter?): PromotionalOffer {
+private class IosPromotionalOffer(val wrapped: NativeIosPromotionalOffer) : PromotionalOffer {
     override val discount: StoreProductDiscount =
-        wrapped.discount().toStoreProductDiscount(priceFormatter)
+        wrapped.discount().toStoreProductDiscount()
 }

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProduct.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProduct.ios.kt
@@ -31,8 +31,9 @@ private class IosStoreProduct(val wrapped: NativeIosStoreProduct): StoreProduct 
     override val defaultOption: SubscriptionOption? = null
     override val discounts: List<StoreProductDiscount> = wrapped.discounts()
         .map { it as IosStoreProductDiscount }
-        .map { it.toStoreProductDiscount(wrapped.priceFormatter()) }
-    override val introductoryDiscount: StoreProductDiscount? = wrapped.introductoryDiscount()?.toStoreProductDiscount(wrapped.priceFormatter())
+        .map { it.toStoreProductDiscount() }
+    override val introductoryDiscount: StoreProductDiscount? =
+        wrapped.introductoryDiscount()?.toStoreProductDiscount()
     override val purchasingData: PurchasingData = IosPurchasingData(wrapped)
     override val presentedOfferingContext: PresentedOfferingContext? = null
 }

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProductDiscount.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProductDiscount.ios.kt
@@ -5,20 +5,17 @@ import com.revenuecat.purchases.kmp.models.DiscountType
 import com.revenuecat.purchases.kmp.models.Period
 import com.revenuecat.purchases.kmp.models.Price
 import com.revenuecat.purchases.kmp.models.StoreProductDiscount
-import platform.Foundation.NSNumberFormatter
 import cocoapods.PurchasesHybridCommon.RCStoreProductDiscount as NativeIosStoreProductDiscount
 
-public fun NativeIosStoreProductDiscount.toStoreProductDiscount(
-    priceFormatter: NSNumberFormatter?,
-): StoreProductDiscount = IosStoreProductDiscount(this, priceFormatter)
+public fun NativeIosStoreProductDiscount.toStoreProductDiscount(): StoreProductDiscount =
+    IosStoreProductDiscount(this)
 
 public fun StoreProductDiscount.toIosStoreProductDiscount(): NativeIosStoreProductDiscount = (this as IosStoreProductDiscount).wrapped
 
 private class IosStoreProductDiscount(
     val wrapped: NativeIosStoreProductDiscount,
-    priceFormatter: NSNumberFormatter?,
 ): StoreProductDiscount {
-    override val price: Price = wrapped.toPrice(priceFormatter)
+    override val price: Price = wrapped.toPrice()
     override val numberOfPeriods: Long = wrapped.numberOfPeriods()
     override val offerIdentifier: String? = wrapped.offerIdentifier()
     override val paymentMode: DiscountPaymentMode = wrapped.paymentMode().toDiscountPaymentMode()


### PR DESCRIPTION
Since PHC did not expose the actual price amount on iOS, we were reconstructing it by parsing the formatted price string. Besides being very brittle, this might also be the cause of https://github.com/RevenueCat/purchases-kmp/issues/161, as we return `0` if the price formatter is null. The meat of this PR is in `Price.ios.kt`. 

**Note**: this is ready for review. It's just dependent on a few external factors:

## Blockers
- [x] https://github.com/RevenueCat/purchases-hybrid-common/pull/911
- [x] A PHC release with ☝️ 
- [x] Updating this PR with the new PHC version number. 