### PR TITLE
Makes issue identifiers clickable in Android Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ fastlane/.env
 # CircleCI
 vendor/
 .bundle/
+
+# Share IssueNavigationConfiguration
+!.idea/vcs.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/RevenueCat/purchases-kmp/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
Adds Issue Navigation settings, which makes comments mentioning an issue / PR have a clickable link straight to it:
![image](https://github.com/user-attachments/assets/37671a60-6e8f-4284-a2dc-2a8dc7422b4b)

