### PR TITLE
Passes the right contexts to the automatic-bump job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,10 @@ workflows:
             - equal: [ "release-train", << pipeline.schedule.name >> ]
         - equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/automatic-bump
+      - revenuecat/automatic-bump:
+          context:
+            - git-user-ops
+            - github-bot-public
 
   # The second stage of the release train starts a hold job, which is a job that
   # needs to be manually approved on the CircleCI web app. This ensures there's 


### PR DESCRIPTION
As the title says. This should fix the release train. ([recent failure](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/512/workflows/4b283678-ceca-473f-8ac0-f8d7b7894ee5/jobs/761))