### PR TITLE
Runs the update-purchases-hybrid-common-version job on macOS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,10 @@ executors:
 jobs:
   update-purchases-hybrid-common-version:
     description: "Opens a PR updating the purchases-hybrid-common dependency to the latest version."
-    executor: ruby3
+    executor: xcode15
     steps:
       - checkout
-      - revenuecat/install-gem-unix-dependencies:
+      - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - revenuecat/trust-github-key
       - revenuecat/setup-git-credentials


### PR DESCRIPTION
We have the Podfile.lock file version controlled. We made sure it gets updated automatically in https://github.com/RevenueCat/purchases-kmp/pull/175, but that requires running a CocoaPods command which [fails on CI](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/579/workflows/2c17864f-f52a-4e67-aac5-fa56244d2e78/jobs/851).

That, in combination with the fact that running the `update_hybrid_common` lane locally in a clean checkout works fine, leads me to believe that the CI job needs to run on macOS. That's what this PR does. 