### PR TITLE
Fixes the PurchasesDelegate being deallocated on iOS

### DIFF
--- a/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/Purchases.kt
+++ b/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/Purchases.kt
@@ -107,6 +107,10 @@ public expect class Purchases {
     /**
      * The delegate is responsible for handling promotional product purchases (App Store only) and
      * changes to customer information.
+     *
+     * **Note:** If your delegate is not a singleton, make sure you set this back to null when
+     * you're done to avoid memory leaks. For instance, if your delegate is tied to a screen, set
+     * this to null when the user navigates away from the screen.
      */
     public var delegate: PurchasesDelegate?
 

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -119,7 +119,7 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
 
     public actual var delegate: PurchasesDelegate?
         get() = iosPurchases.delegate()?.toPurchasesDelegate()
-        set(value) = iosPurchases.setDelegate(value?.toRcPurchasesDelegate())
+        set(value) = iosPurchases.setDelegate(value.toRcPurchasesDelegate())
 
     public actual val isAnonymous: Boolean
         get() = iosPurchases.isAnonymous()

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.kmp
 
 import cocoapods.PurchasesHybridCommon.RCCommonFunctionality
+import cocoapods.PurchasesHybridCommon.RCPurchasesDelegateProtocol
 import cocoapods.PurchasesHybridCommon.RCStoreProduct
 import cocoapods.PurchasesHybridCommon.configureWithAPIKey
 import cocoapods.PurchasesHybridCommon.recordPurchaseForProductID
@@ -117,9 +118,18 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
     public actual val appUserID: String
         get() = iosPurchases.appUserID()
 
+    /**
+     * Making sure we keep a strong reference to our delegate wrapper, as iosPurchases only keeps
+     * a weak one. This avoids the wrapper from being deallocated the first chance it gets. This
+     * behavior matches the Android platform behavior.
+     */
+    private var _delegateWrapper: RCPurchasesDelegateProtocol? = null
     public actual var delegate: PurchasesDelegate?
         get() = iosPurchases.delegate()?.toPurchasesDelegate()
-        set(value) = iosPurchases.setDelegate(value.toRcPurchasesDelegate())
+        set(value) {
+            _delegateWrapper = value.toRcPurchasesDelegate()
+            iosPurchases.setDelegate(_delegateWrapper)
+        }
 
     public actual val isAnonymous: Boolean
         get() = iosPurchases.isAnonymous()

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -340,7 +340,7 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
     }
 
     public actual fun close() {
-        iosPurchases.setDelegate(null)
+        delegate = null
     }
 
     public actual fun getCustomerInfo(

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/PurchasesDelegate.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/PurchasesDelegate.ios.kt
@@ -15,8 +15,9 @@ import platform.darwin.NSObject
 internal fun RCPurchasesDelegateProtocol.toPurchasesDelegate(): PurchasesDelegate =
     (this as PurchasesDelegateWrapper).wrapped
 
-internal fun PurchasesDelegate.toRcPurchasesDelegate(): RCPurchasesDelegateProtocol =
-    PurchasesDelegateWrapper(this)
+internal fun PurchasesDelegate?.toRcPurchasesDelegate(): RCPurchasesDelegateProtocol? =
+    this?.let { PurchasesDelegateWrapper(it) }
+        .also { PurchasesDelegateStrongReference.delegate = it }
 
 private class PurchasesDelegateWrapper(val wrapped: PurchasesDelegate) :
     RCPurchasesDelegateProtocol,
@@ -44,4 +45,21 @@ private class PurchasesDelegateWrapper(val wrapped: PurchasesDelegate) :
         wrapped.onCustomerInfoUpdated(receivedUpdatedCustomerInfo.toCustomerInfo())
     }
 
+}
+
+/**
+ * On the iOS platform side, the backing field of `Purchases.delegate`, `Purchases.privateDelegate`,
+ * is a `weak var`. On the multiplatform side, we wrap the actual delegate in
+ * `PurchasesDelegateWrapper` to conform to `RCPurchasesDelegateProtocol`. Since that is a private
+ * implementation detail, the only reference held to our wrapper is the `weak var`. This means that
+ * it gets deallocated the first chance it gets. For this reason, we keep a strong reference to our
+ * `PurchasesDelegateWrapper` here. This matches the Android behavior, which keeps a strong
+ * reference on the platform side already.
+ *
+ * **Note**: we cannot make our `PurchasesDelegateWrapper` an `object` directly, as objects cannot
+ * extend `NSObject`. See also
+ * [KT67930](https://youtrack.jetbrains.com/issue/KT-67930/Getting-Crash-while-building-KMM-project-with-XCode-15.3#focus=Comments-27-9796215.0-0)
+ */
+private object PurchasesDelegateStrongReference {
+    var delegate: RCPurchasesDelegateProtocol? = null
 }

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/PurchasesDelegate.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/PurchasesDelegate.ios.kt
@@ -17,7 +17,6 @@ internal fun RCPurchasesDelegateProtocol.toPurchasesDelegate(): PurchasesDelegat
 
 internal fun PurchasesDelegate?.toRcPurchasesDelegate(): RCPurchasesDelegateProtocol? =
     this?.let { PurchasesDelegateWrapper(it) }
-        .also { PurchasesDelegateStrongReference.delegate = it }
 
 private class PurchasesDelegateWrapper(val wrapped: PurchasesDelegate) :
     RCPurchasesDelegateProtocol,
@@ -45,21 +44,4 @@ private class PurchasesDelegateWrapper(val wrapped: PurchasesDelegate) :
         wrapped.onCustomerInfoUpdated(receivedUpdatedCustomerInfo.toCustomerInfo())
     }
 
-}
-
-/**
- * On the iOS platform side, the backing field of `Purchases.delegate`, `Purchases.privateDelegate`,
- * is a `weak var`. On the multiplatform side, we wrap the actual delegate in
- * `PurchasesDelegateWrapper` to conform to `RCPurchasesDelegateProtocol`. Since that is a private
- * implementation detail, the only reference held to our wrapper is the `weak var`. This means that
- * it gets deallocated the first chance it gets. For this reason, we keep a strong reference to our
- * `PurchasesDelegateWrapper` here. This matches the Android behavior, which keeps a strong
- * reference on the platform side already.
- *
- * **Note**: we cannot make our `PurchasesDelegateWrapper` an `object` directly, as objects cannot
- * extend `NSObject`. See also
- * [KT67930](https://youtrack.jetbrains.com/issue/KT-67930/Getting-Crash-while-building-KMM-project-with-XCode-15.3#focus=Comments-27-9796215.0-0)
- */
-private object PurchasesDelegateStrongReference {
-    var delegate: RCPurchasesDelegateProtocol? = null
 }


### PR DESCRIPTION
## Bug
The `PurchasesDelegate` sometimes doesn't get called on iOS.

## Cause
On the iOS platform side, the backing field of `Purchases.delegate`, `Purchases.privateDelegate`, is a [`weak var`](https://github.com/RevenueCat/purchases-ios/blob/b695ac1866f2fd56c7484b53b003cdc70adcd1ca/Sources/Purchasing/Purchases/Purchases.swift#L105). On the multiplatform side, we wrap the actual delegate in `PurchasesDelegateWrapper` to conform to `RCPurchasesDelegateProtocol`. Since that is a private implementation detail, the only reference held to our wrapper is the `weak var`. This means that it gets deallocated the first chance it gets. 

## Fix
We keep a strong reference to our `PurchasesDelegateWrapper`. This matches the Android behavior, which keeps a strong reference on the platform side already.

Fixes #203 