### PR TITLE
Skips publishing SNAPSHOT if the current version is not a SNAPSHOT.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,7 +149,7 @@ lane :publish_if_snapshot do |options|
   if version.end_with?("-SNAPSHOT")
     publish
   else
-    UI.user_error!("The current version '#{version}' is not a SNAPSHOT version.")
+    UI.verbose!("The current version '#{version}' is not a SNAPSHOT version, so nothing will be published.")
   end
 end
 


### PR DESCRIPTION
As the title says. This used to error out, but that meant CI would always fail right after a release, before the version is updated to `-SNAPSHOT`. Example [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/686/workflows/8c04110b-b29c-4522-8ec9-9587a15c1340/jobs/1613).