### PR TITLE
Attempts to fix the on_release_tag workflow to allow publishing the API reference site

### DIFF
--- a/.github/workflows/on_release_tag.yml
+++ b/.github/workflows/on_release_tag.yml
@@ -3,11 +3,10 @@ name: On release tag
 on:
   push:
     tags:
-      - '^[0-9]+\\.[0-9]+\\.[0-9]+(?!.*-SNAPSHOT).*$'
+      - '[0-9]+.[0-9]+.[0-9]+\+?[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   generate-api-reference:
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Turns out you can't use regex for filters on GitHub Actions. 😄 Also, it still required the `build` job which is no longer defined here. It now passes on https://rhysd.github.io/actionlint/. 
 
Note that this implicitly still requires a successful build, as the release tag won't be pushed if it didn't pass on CircleCI. 
 
For reference, here's the [filter pattern cheat sheet](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).