### PR TITLE
Attempts to fix ffi by removing the platform specification.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,4 @@ gem 'rb-readline'
 gem 'fastlane'
 gem 'cocoapods'
 
-# Workaround for https://github.com/ffi/ffi/issues/1105
-# https://bundler.io/v2.5/man/gemfile.5.html#FORCE_RUBY_PLATFORM
-gem 'ffi', force_ruby_platform: true
-
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,8 @@ gem 'rb-readline'
 gem 'fastlane'
 gem 'cocoapods'
 
+# Workaround for https://github.com/ffi/ffi/issues/1105
+# https://bundler.io/v2.5/man/gemfile.5.html#FORCE_RUBY_PLATFORM
+gem 'ffi', force_ruby_platform: true
+
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,8 +195,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -350,6 +349,7 @@ DEPENDENCIES
   danger
   fastlane
   fastlane-plugin-revenuecat_internal!
+  ffi
   rb-readline
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    ffi (1.17.0)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,9 +254,10 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     logger (1.6.1)
-    mime-types (3.5.2)
+    mime-types (3.6.0)
+      logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0903)
+    mime-types-data (3.2024.1001)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,6 @@ DEPENDENCIES
   danger
   fastlane
   fastlane-plugin-revenuecat_internal!
-  ffi
   rb-readline
 
 BUNDLED WITH


### PR DESCRIPTION
## Bug
We've been getting [this error on CircleC](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/729/workflows/cb0011c8-96a8-4bff-b975-22d611beb331/jobs/2015)I:

> Your bundle is locked to ffi (1.17.0-arm64-darwin) from rubygems repository
https://rubygems.org/ or installed locally, but that version can no longer be
found in that source. That means the author of ffi (1.17.0-arm64-darwin) has
removed it. You'll need to update your bundle to a version other than ffi
(1.17.0-arm64-darwin) that hasn't been removed in order to install. 

## Cause
However, 1.17.0 is the latest version at the time of writing. Others have similar issues, e.g. see: https://github.com/ffi/ffi/issues/1105. It is mentioned in that thread that the platform specification in `Gemfile.lock` causes the issue. In our case, it also seems likely that the platform specification causes issues, as the error mentions darwin, but the CIrcleCI job runs in a Docker container.

## Fix
The implemented fix is to downgrade to the version we use in purchases-ios: `1.16.3`. ([1.17.0 is the first version to introduce per-platform binaries.](https://github.com/ffi/ffi/releases/tag/v1.17.0.rc1))

## Alternative fix (not in this PR)
This fix is not in this PR, but documented in case the implemented fix doesn't work. In that case, we can try this next.

1. Remove the any `ffi` lines from the original `Gemfile.lock`, except lines declaring a transitive dependency. 
2. Add [`force_ruby_platform`](https://bundler.io/v2.5/man/gemfile.5.html#FORCE_RUBY_PLATFORM)  to the `Gemfile`.
3. Run `bundle install`.