### PR TITLE
Adds `Offerings.getCurrentOfferingForPlacement()`

### DIFF
--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/OfferingsAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/OfferingsAPI.kt
@@ -5,6 +5,24 @@ import com.revenuecat.purchases.kmp.models.Offerings
 
 @Suppress("unused", "UNUSED_VARIABLE")
 private class OfferingsAPI {
+
+    fun checkConstructor(
+        all: Map<String, Offering>,
+        current: Offering?,
+        getCurrentOfferingForPlacement: (placementId: String) -> Offering?
+    ) {
+        val offerings1 = Offerings(
+            all = all,
+            current = current
+        )
+
+        val offerings2 = Offerings(
+            all = all,
+            current = current,
+            getCurrentOfferingForPlacement = getCurrentOfferingForPlacement,
+        )
+    }
+
     fun check(offerings: Offerings) {
         with(offerings) {
             val current: Offering? = current

--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/OfferingsAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/OfferingsAPI.kt
@@ -29,6 +29,7 @@ private class OfferingsAPI {
             val all: Map<String, Offering> = all
             val o1: Offering? = getOffering("")
             val o2: Offering? = this[""]
+            val o3: Offering? = getCurrentOfferingForPlacement("")
         }
     }
 }

--- a/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.android.kt
+++ b/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.android.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.Offerings as AndroidOfferings
 public fun AndroidOfferings.toOfferings(): Offerings {
     return Offerings(
         all = all.mapValues { it.value.toOffering() },
-        current = current?.toOffering()
+        current = current?.toOffering(),
+        getCurrentOfferingForPlacement = { getCurrentOfferingForPlacement(it)?.toOffering() }
     )
 }

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
 import com.revenuecat.purchases.kmp.models.Offerings
+import cocoapods.PurchasesHybridCommon.RCOffering as IosOffering
 import cocoapods.PurchasesHybridCommon.RCOfferings as IosOfferings
 
 public fun IosOfferings.toOfferings(): Offerings =

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
@@ -1,8 +1,7 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import com.revenuecat.purchases.kmp.models.Offerings
 import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
-import cocoapods.PurchasesHybridCommon.RCOffering as IosOffering
+import com.revenuecat.purchases.kmp.models.Offerings
 import cocoapods.PurchasesHybridCommon.RCOfferings as IosOfferings
 
 public fun IosOfferings.toOfferings(): Offerings =
@@ -10,5 +9,6 @@ public fun IosOfferings.toOfferings(): Offerings =
         current = current()?.toOffering(),
         all = all().mapEntries { (offeringId, offering) ->
             offeringId as String to (offering as IosOffering).toOffering()
-        }
+        },
+        getCurrentOfferingForPlacement = { TODO() }
     )

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
@@ -1,5 +1,6 @@
 package com.revenuecat.purchases.kmp.mappings
 
+import cocoapods.PurchasesHybridCommon.currentOfferingForPlacement
 import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
 import com.revenuecat.purchases.kmp.models.Offerings
 import cocoapods.PurchasesHybridCommon.RCOffering as IosOffering
@@ -11,5 +12,7 @@ public fun IosOfferings.toOfferings(): Offerings =
         all = all().mapEntries { (offeringId, offering) ->
             offeringId as String to (offering as IosOffering).toOffering()
         },
-        getCurrentOfferingForPlacement = { TODO() }
+        getCurrentOfferingForPlacement = {
+            currentOfferingForPlacement(it)?.toOffering()
+        }
     )

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -150,9 +150,11 @@ public final class com/revenuecat/purchases/kmp/models/Offering$DefaultImpls {
 
 public final class com/revenuecat/purchases/kmp/models/Offerings {
 	public fun <init> (Ljava/util/Map;Lcom/revenuecat/purchases/kmp/models/Offering;)V
+	public fun <init> (Ljava/util/Map;Lcom/revenuecat/purchases/kmp/models/Offering;Lkotlin/jvm/functions/Function1;)V
 	public final fun get (Ljava/lang/String;)Lcom/revenuecat/purchases/kmp/models/Offering;
 	public final fun getAll ()Ljava/util/Map;
 	public final fun getCurrent ()Lcom/revenuecat/purchases/kmp/models/Offering;
+	public final fun getCurrentOfferingForPlacement (Ljava/lang/String;)Lcom/revenuecat/purchases/kmp/models/Offering;
 	public final fun getOffering (Ljava/lang/String;)Lcom/revenuecat/purchases/kmp/models/Offering;
 }
 

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -212,7 +212,9 @@ final class com.revenuecat.purchases.kmp.models/InstallmentsInfo { // com.revenu
 }
 final class com.revenuecat.purchases.kmp.models/Offerings { // com.revenuecat.purchases.kmp.models/Offerings|null[0]
     constructor <init>(kotlin.collections/Map<kotlin/String, com.revenuecat.purchases.kmp.models/Offering>, com.revenuecat.purchases.kmp.models/Offering?) // com.revenuecat.purchases.kmp.models/Offerings.<init>|<init>(kotlin.collections.Map<kotlin.String,com.revenuecat.purchases.kmp.models.Offering>;com.revenuecat.purchases.kmp.models.Offering?){}[0]
+    constructor <init>(kotlin.collections/Map<kotlin/String, com.revenuecat.purchases.kmp.models/Offering>, com.revenuecat.purchases.kmp.models/Offering?, kotlin/Function1<kotlin/String, com.revenuecat.purchases.kmp.models/Offering?>) // com.revenuecat.purchases.kmp.models/Offerings.<init>|<init>(kotlin.collections.Map<kotlin.String,com.revenuecat.purchases.kmp.models.Offering>;com.revenuecat.purchases.kmp.models.Offering?;kotlin.Function1<kotlin.String,com.revenuecat.purchases.kmp.models.Offering?>){}[0]
     final fun get(kotlin/String): com.revenuecat.purchases.kmp.models/Offering? // com.revenuecat.purchases.kmp.models/Offerings.get|get(kotlin.String){}[0]
+    final fun getCurrentOfferingForPlacement(kotlin/String): com.revenuecat.purchases.kmp.models/Offering? // com.revenuecat.purchases.kmp.models/Offerings.getCurrentOfferingForPlacement|getCurrentOfferingForPlacement(kotlin.String){}[0]
     final fun getOffering(kotlin/String): com.revenuecat.purchases.kmp.models/Offering? // com.revenuecat.purchases.kmp.models/Offerings.getOffering|getOffering(kotlin.String){}[0]
     final val all // com.revenuecat.purchases.kmp.models/Offerings.all|{}all[0]
         final fun <get-all>(): kotlin.collections/Map<kotlin/String, com.revenuecat.purchases.kmp.models/Offering> // com.revenuecat.purchases.kmp.models/Offerings.all.<get-all>|<get-all>(){}[0]

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/Offerings.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/Offerings.kt
@@ -13,8 +13,31 @@ public class Offerings(
     /**
      * Current offering configured in the RevenueCat dashboard.
      */
-    public val current: Offering?
+    public val current: Offering?,
+
+    /**
+     * An implementation to retrieves a specific offering by placement identifier.
+     */
+    private val getCurrentOfferingForPlacement: (placementId: String) -> Offering?
 ) {
+
+    // @JvmOverloads doesn't work for ObjC.
+    public constructor(
+        /**
+         * Dictionary of all Offerings [Offering] objects keyed by their identifier.
+         */
+        all: Map<String, Offering>,
+
+        /**
+         * Current offering configured in the RevenueCat dashboard.
+         */
+        current: Offering?,
+    ) : this(
+        all = all,
+        current = current,
+        getCurrentOfferingForPlacement = { null }
+    )
+
     /**
      * Retrieves an specific offering by its identifier. It's equivalent to
      * calling [getOffering(identifier)]
@@ -27,4 +50,11 @@ public class Offerings(
      * @param identifier Offering identifier
      */
     public fun getOffering(identifier: String): Offering? = all[identifier]
+
+    /**
+     * Retrieves a specific offering by placement identifier. For more info see the
+     * [RevenueCat docs](https://www.revenuecat.com/docs/tools/targeting).
+     */
+    public fun getCurrentOfferingForPlacement(placementId: String): Offering? =
+        getCurrentOfferingForPlacement.invoke(placementId)
 }

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/Offerings.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/Offerings.kt
@@ -16,7 +16,7 @@ public class Offerings(
     public val current: Offering?,
 
     /**
-     * An implementation to retrieves a specific offering by placement identifier.
+     * An implementation to retrieve a specific offering by placement identifier.
      */
     private val getCurrentOfferingForPlacement: (placementId: String) -> Offering?
 ) {


### PR DESCRIPTION
This adds the `Offerings.getCurrentOfferingForPlacement()` functionality back, which was removed in https://github.com/RevenueCat/purchases-kmp/pull/121. 

In order to make this non-breaking, I added a lambda constructor parameter to `Offerings`. I don't entirely love it, but all the alternatives I could think of are breaking in one way or another (e.g. making `Offerings` an interface). Please do let me know all your ideas! I'm also happy to discuss this more. 

- Dependency: https://github.com/RevenueCat/purchases-hybrid-common/pull/938
- Addresses: https://github.com/RevenueCat/purchases-kmp/issues/242