### PR TITLE
Fixes iOS PaywallFooter height

### DIFF
--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallFooter.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallFooter.kt
@@ -1,18 +1,15 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
@@ -25,18 +22,17 @@ public actual fun PaywallFooter(
     options: PaywallOptions,
     mainContent: @Composable ((PaddingValues) -> Unit)?,
 ) {
-    var height by remember { mutableStateOf(0.dp) }
     val paywallComposable = @Composable {
         UIKitPaywall(
             options = options,
             footer = true,
             modifier = Modifier
                 .fillMaxWidth()
+                .animateContentSize()
+                .wrapContentHeight()
                 .clip(
                     RoundedCornerShape(topStart = DefaultCornerRadius, topEnd = DefaultCornerRadius)
-                )
-                .height(height),
-            onHeightChange = { newHeight -> height = newHeight.dp }
+                ),
         )
     }
 

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallFooter.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallFooter.kt
@@ -1,6 +1,5 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,7 +35,6 @@ public actual fun PaywallFooter(
                 .clip(
                     RoundedCornerShape(topStart = DefaultCornerRadius, topEnd = DefaultCornerRadius)
                 )
-                .animateContentSize()
                 .height(height),
             onHeightChange = { newHeight -> height = newHeight.dp }
         )

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -6,10 +6,6 @@ import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
 import com.revenuecat.purchases.kmp.mappings.toPackage
 import com.revenuecat.purchases.kmp.mappings.toPurchasesErrorOrThrow
 import com.revenuecat.purchases.kmp.mappings.toStoreTransaction
-import kotlinx.cinterop.CValue
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.pointed
-import platform.CoreGraphics.CGSize
 import platform.Foundation.NSError
 import platform.darwin.NSObject
 import cocoapods.PurchasesHybridCommon.RCCustomerInfo as PhcCustomerInfo
@@ -21,7 +17,6 @@ import objcnames.classes.RCStoreTransaction as ObjcNamesStoreTransaction
 
 internal class IosPaywallDelegate(
     private val listener: PaywallListener?,
-    private val onHeightChange: (Int) -> Unit
 ) : RCPaywallViewControllerDelegateProtocol,
     NSObject() {
 
@@ -79,15 +74,5 @@ internal class IosPaywallDelegate(
         didFailRestoringWithError: NSError
     ) {
         listener?.onRestoreError(didFailRestoringWithError.toPurchasesErrorOrThrow())
-    }
-
-
-    override fun paywallViewController(
-        controller: RCPaywallViewController,
-        didChangeSizeTo: CValue<CGSize>
-    ) {
-        var height: Int? = null
-        memScoped { height = didChangeSizeTo.ptr.pointed.height.toInt() }
-        onHeightChange(height!!)
     }
 }

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -6,6 +6,10 @@ import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
 import com.revenuecat.purchases.kmp.mappings.toPackage
 import com.revenuecat.purchases.kmp.mappings.toPurchasesErrorOrThrow
 import com.revenuecat.purchases.kmp.mappings.toStoreTransaction
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import platform.CoreGraphics.CGSize
 import platform.Foundation.NSError
 import platform.darwin.NSObject
 import cocoapods.PurchasesHybridCommon.RCCustomerInfo as PhcCustomerInfo
@@ -17,6 +21,7 @@ import objcnames.classes.RCStoreTransaction as ObjcNamesStoreTransaction
 
 internal class IosPaywallDelegate(
     private val listener: PaywallListener?,
+    private val onHeightChange: (Int) -> Unit
 ) : RCPaywallViewControllerDelegateProtocol,
     NSObject() {
 
@@ -74,5 +79,15 @@ internal class IosPaywallDelegate(
         didFailRestoringWithError: NSError
     ) {
         listener?.onRestoreError(didFailRestoringWithError.toPurchasesErrorOrThrow())
+    }
+
+
+    override fun paywallViewController(
+        controller: RCPaywallViewController,
+        didChangeSizeTo: CValue<CGSize>
+    ) {
+        var height: Int? = null
+        memScoped { height = didChangeSizeTo.ptr.pointed.height.toInt() }
+        onHeightChange(height!!)
     }
 }

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
@@ -3,7 +3,7 @@ package com.revenuecat.purchases.kmp.ui.revenuecatui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.interop.UIKitViewController
+import androidx.compose.ui.viewinterop.UIKitViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallFooterViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
 import com.revenuecat.purchases.kmp.mappings.toIosOffering

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
@@ -1,8 +1,14 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallFooterViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
@@ -17,17 +23,45 @@ internal fun UIKitPaywall(
     options: PaywallOptions,
     footer: Boolean,
     modifier: Modifier = Modifier,
-    onHeightChange: (Int) -> Unit = { },
 ) {
-    // Keeping references to avoid them being deallocated.
-    val dismissRequestedHandler: (RCPaywallViewController?) -> Unit =
-        remember(options.dismissRequest) { { options.dismissRequest() } }
-    val delegate = remember(options.listener) { IosPaywallDelegate(options.listener) }
+    val density = LocalDensity.current
+
+    /**
+     * Our intrinsic content size according to UIKit.
+     */
+    var intrinsicContentSizePx by remember { mutableStateOf(0) }
+
     // We remember this wrapper so we can keep a reference to RCPaywallViewController, even during
     // recompositions. RCPaywallViewController itself is not yet instantiated here.
     val viewControllerWrapper = remember { ViewControllerWrapper(null) }
+
+    // Keeping references to avoid them being deallocated.
+    val dismissRequestedHandler: (RCPaywallViewController?) -> Unit =
+        remember(options.dismissRequest) { { options.dismissRequest() } }
+    val delegate = remember(options.listener) {
+        IosPaywallDelegate(options.listener) {
+            // UIKit reports that our height was updated, so we're updating intrinsicContentSizePx
+            // to force a new measurement phase (below).
+            viewControllerWrapper.value?.view
+                ?.getIntrinsicContentSizeOfFirstSubView()
+                ?.also { intrinsicContentSizePx = with(density) { it.dp.roundToPx() } }
+        }
+    }
+
     UIKitViewController(
-        modifier = modifier,
+        modifier = modifier.layout { measurable, constraints ->
+            val placeable = measurable.measure(
+                if (constraints.minHeight == 0 && constraints.maxHeight > 0)
+                // We are being asked to wrap our own content height. We will use the measurement
+                // done by UIKit.
+                    constraints.copy(minHeight = intrinsicContentSizePx)
+                else constraints
+            )
+
+            layout(placeable.width, placeable.height) {
+                placeable.placeRelative(0, 0)
+            }
+        },
         factory = {
             val viewController = if (footer) RCPaywallFooterViewController(
                 offering = options.offering?.toIosOffering() as? RCOffering,
@@ -43,12 +77,10 @@ internal fun UIKitPaywall(
 
             viewController
                 .also {
-                    // The first subview has an actual intrinsic content size. We immediately let
-                    // the parent know, so it can set our height accordingly. This should happen
-                    // before the first frame is drawn.
-                    if (footer) (it.view.subviews.firstOrNull() as? UIView)
-                        ?.getIntrinsicContentSize()
-                        ?.also(onHeightChange)
+                    // The first subview has an actual intrinsic content size. We keep a reference
+                    // so we can use it in our measurement phase (above).
+                    it.view.getIntrinsicContentSizeOfFirstSubView()
+                        ?.also { intrinsicContentSizePx = with(density) { it.dp.roundToPx() } }
                 }
                 .apply { setDelegate(delegate) }
                 .also { viewControllerWrapper.value = it }
@@ -61,6 +93,10 @@ private fun UIView.getIntrinsicContentSize(): Int {
     memScoped { size = intrinsicContentSize.ptr.pointed.height.toInt() }
     return size!!
 }
+
+private fun UIView.getIntrinsicContentSizeOfFirstSubView(): Int? =
+    (subviews.firstOrNull() as? UIView)?.getIntrinsicContentSize()
+
 
 /**
  * Can be [remembered][remember] before the RCPaywallViewController is instantiated, so as to


### PR DESCRIPTION
This is a regression introduced by Compose Multiplatform 1.7.0. 

## Bug
The `PaywallFooter` is not laid out correctly. Its height is correct, but it is placed too low in its container. This only happens on iOS. Android is fine. 

## Cause
After some experimentation with safe area insets, I found that it is actually caused by `animateContentSize()`. We are using this, because we don't immediately know the height of the footer. So we set it at 0 at first, and then animate it up once we know it. 

## Fix
Removing the `animateContentSize()` modifier completely fixes the layout. 

## Improvement
I dug a bit deeper, and was actually able to avoid the need for the animation by figuring out the footer height before the first frame is drawn, using `intrinsincContentSize`. This means the footer is immediately of the right height, no animations or janky frames. 

## Comparison

| Before | After |
|--------|-------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-10-17 at 19 03 41](https://github.com/user-attachments/assets/f3757320-5b14-4e1f-9169-b7b818ebcadc) | ![Simulator Screenshot - iPhone 15 Pro - 2024-10-17 at 18 58 15](https://github.com/user-attachments/assets/c4504427-bc94-4b47-9b59-46044d64ad99) |