### PR TITLE
Support displaying deferred win-back StoreKit messages

### DIFF
--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/StoreMessageTypeAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/StoreMessageTypeAPI.kt
@@ -8,7 +8,9 @@ private class StoreMessageTypeAPI {
         when (type) {
             StoreMessageType.BILLING_ISSUES,
             StoreMessageType.GENERIC,
-            StoreMessageType.PRICE_INCREASE_CONSENT -> {
+            StoreMessageType.PRICE_INCREASE_CONSENT,
+            StoreMessageType.WIN_BACK_OFFER -> {
+                
             }
         }.exhaustive
     }

--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
@@ -421,6 +421,7 @@ public actual class Purchases private constructor(private val androidPurchases: 
         when (this) {
             StoreMessageType.BILLING_ISSUES -> InAppMessageType.BILLING_ISSUES
             StoreMessageType.GENERIC,
+            StoreMessageType.WIN_BACK_OFFER,
             StoreMessageType.PRICE_INCREASE_CONSENT -> null
         }
 

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -372,6 +372,7 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
                 StoreMessageType.BILLING_ISSUES -> 0
                 StoreMessageType.PRICE_INCREASE_CONSENT -> 1
                 StoreMessageType.GENERIC -> 2
+                StoreMessageType.WIN_BACK_OFFER -> 3
             }
         },
         completion = { }

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -395,6 +395,7 @@ public final class com/revenuecat/purchases/kmp/models/StoreMessageType : java/l
 	public static final field BILLING_ISSUES Lcom/revenuecat/purchases/kmp/models/StoreMessageType;
 	public static final field GENERIC Lcom/revenuecat/purchases/kmp/models/StoreMessageType;
 	public static final field PRICE_INCREASE_CONSENT Lcom/revenuecat/purchases/kmp/models/StoreMessageType;
+	public static final field WIN_BACK_OFFER Lcom/revenuecat/purchases/kmp/models/StoreMessageType;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/revenuecat/purchases/kmp/models/StoreMessageType;
 	public static fun values ()[Lcom/revenuecat/purchases/kmp/models/StoreMessageType;

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -514,6 +514,7 @@ final enum class com.revenuecat.purchases.kmp.models/StoreMessageType : kotlin/E
     enum entry BILLING_ISSUES // com.revenuecat.purchases.kmp.models/StoreMessageType.BILLING_ISSUES|null[0]
     enum entry GENERIC // com.revenuecat.purchases.kmp.models/StoreMessageType.GENERIC|null[0]
     enum entry PRICE_INCREASE_CONSENT // com.revenuecat.purchases.kmp.models/StoreMessageType.PRICE_INCREASE_CONSENT|null[0]
+    enum entry WIN_BACK_OFFER // com.revenuecat.purchases.kmp.models/StoreMessageType.WIN_BACK_OFFER|null[0]
     final fun valueOf(kotlin/String): com.revenuecat.purchases.kmp.models/StoreMessageType // com.revenuecat.purchases.kmp.models/StoreMessageType.valueOf|valueOf#static(kotlin.String){}[0]
     final fun values(): kotlin/Array<com.revenuecat.purchases.kmp.models/StoreMessageType> // com.revenuecat.purchases.kmp.models/StoreMessageType.values|values#static(){}[0]
     final val entries // com.revenuecat.purchases.kmp.models/StoreMessageType.entries|#static{}entries[0]

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/StoreMessageType.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/StoreMessageType.kt
@@ -21,4 +21,10 @@ public enum class StoreMessageType {
      * App Store only. Generic store messages.
      */
     GENERIC,
+
+    /**
+     * App Store only. This message will show if the subscriber is eligible for an iOS win-back
+     * offer and will allow the subscriber to redeem the offer.
+     */
+    WIN_BACK_OFFER,
 }


### PR DESCRIPTION
This PR introduces the ability for a developer to display deferred StoreKit win-back offer messages to the user. The functionality was originally introduced in https://github.com/RevenueCat/purchases-ios/pull/4343.

Other than the enum addition, no other changes are necessary.