### PR TITLE
Avoids unnecessary scrolling delay on Customer Center iOS

### DIFF
--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitCustomerCenter.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitCustomerCenter.kt
@@ -1,6 +1,10 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
@@ -8,9 +12,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitViewController
 import cocoapods.PurchasesHybridCommonUI.CustomerCenterUIViewController
 import cocoapods.PurchasesHybridCommonUI.RCCustomerCenterViewControllerDelegateWrapperProtocol
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.pointed
-import platform.UIKit.UIView
 import platform.darwin.NSObject
 
 @Composable
@@ -47,6 +48,7 @@ internal fun UIKitCustomerCenter(
                     ?.also { intrinsicContentSizePx = with(density) { it.dp.roundToPx() } }
             }
         },
+        properties = nonCooperativeUiKitInteropPropertiesNonExperimental()
     )
 }
 

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitInteropPropertiesKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitInteropPropertiesKtx.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.kmp.ui.revenuecatui
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.viewinterop.UIKitInteropProperties
+
+/**
+ * Uses NonCooperative UIKitInteropInteractionMode if available, for snappy scrolling.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun nonCooperativeUiKitInteropPropertiesNonExperimental(): UIKitInteropProperties =
+    try {
+        // This UIKitInteropProperties constructor and the UIKitInteropInteractionMode type are
+        // experimental at the time of writing. We try to use them, but this could fail if we're
+        // linked against a newer version of CMP that changed this API. If so, we fall back to the
+        // non-experimental constructor.
+        // In that scenario, there's an added delay when scrolling the paywall.
+        UIKitInteropProperties(
+            // Not importing this type on purpose, because it is experimental, and we want to catch
+            // any linkage errors here.
+            interactionMode = androidx.compose.ui.viewinterop.UIKitInteropInteractionMode.NonCooperative,
+        )
+    } catch (e: Error) {
+        // It would actually throw an IrLinkageError, but that type is internal, so we're catching
+        // its supertype instead (which is basically a Throwable).
+        UIKitInteropProperties(
+            isInteractive = true,
+            isNativeAccessibilityEnabled = false,
+        )
+    }

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
@@ -5,20 +5,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallFooterViewController
 import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
 import com.revenuecat.purchases.kmp.mappings.toIosOffering
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.pointed
 import objcnames.classes.RCOffering
-import platform.UIKit.UIView
 
 @Composable
 internal fun UIKitPaywall(
@@ -96,28 +91,3 @@ internal fun UIKitPaywall(
  * "reserve" a spot in the Compose slot table.
  */
 private class ViewControllerWrapper(var value: RCPaywallViewController?)
-
-/**
- * Uses NonCooperative UIKitInteropInteractionMode if available, for snappy scrolling.
- */
-@OptIn(ExperimentalComposeUiApi::class)
-private fun nonCooperativeUiKitInteropPropertiesNonExperimental(): UIKitInteropProperties =
-    try {
-        // This UIKitInteropProperties constructor and the UIKitInteropInteractionMode type are
-        // experimental at the time of writing. We try to use them, but this could fail if we're
-        // linked against a newer version of CMP that changed this API. If so, we fall back to the
-        // non-experimental constructor.
-        // In that scenario, there's an added delay when scrolling the paywall.
-        UIKitInteropProperties(
-            // Not importing this type on purpose, because it is experimental, and we want to catch
-            // any linkage errors here.
-            interactionMode = androidx.compose.ui.viewinterop.UIKitInteropInteractionMode.NonCooperative,
-        )
-    } catch (e: Error) {
-        // It would actually throw an IrLinkageError, but that type is internal, so we're catching
-        // its supertype instead (which is basically a Throwable).
-        UIKitInteropProperties(
-            isInteractive = true,
-            isNativeAccessibilityEnabled = false,
-        )
-    }


### PR DESCRIPTION
## Description
This was a recent improvement to iOS paywalls: https://github.com/RevenueCat/purchases-kmp/pull/340. It applies to Customer Center too, so I'm adding it here. It makes the scrolling much snappier on iOS. 