### PR TITLE
Attempts to fix ffi by removing the platform specification.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,8 @@ gem 'rb-readline'
 gem 'fastlane'
 gem 'cocoapods'
 
+# Workaround for https://github.com/ffi/ffi/issues/1105
+# https://bundler.io/v2.5/man/gemfile.5.html#FORCE_RUBY_PLATFORM
+gem 'ffi', force_ruby_platform: true
+
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,8 +202,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-linux)
+    ffi (1.17.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -353,6 +352,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -360,6 +360,7 @@ DEPENDENCIES
   danger
   fastlane
   fastlane-plugin-revenuecat_internal!
+  ffi
   rb-readline
 
 BUNDLED WITH


### PR DESCRIPTION
## Description
[#352](https://github.com/RevenueCat/purchases-kmp/pull/352) reintroduced an [issue](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/1230/workflows/3c8da019-71ea-4a5e-b385-f47994fbd7b0/jobs/6619) where `ffi` specifies a platform that does not match with CI. We've seen this before in https://github.com/RevenueCat/purchases-kmp/pull/234. Back then we opted to downgrade, but I'm proposing to implement the `force_ruby_platform` workaround from that PR's [first commit](https://github.com/RevenueCat/purchases-kmp/pull/234/commits/8572b8ff50790ededcd002992d4a726f9f636313) now, as we otherwise need to keep remembering to downgrade `ffi`. 