### PR TITLE
Add `Paddle` Store

### DIFF
--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/StoreAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/StoreAPI.kt
@@ -15,6 +15,7 @@ private class StoreAPI {
             Store.AMAZON,
             Store.RC_BILLING,
             Store.EXTERNAL,
+            Store.PADDLE,
             -> {
             }
         }.exhaustive

--- a/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/Store.android.kt
+++ b/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/Store.android.kt
@@ -14,6 +14,7 @@ public fun AndroidStore.toStore(): Store =
         AndroidStore.AMAZON -> Store.AMAZON
         AndroidStore.RC_BILLING -> Store.RC_BILLING
         AndroidStore.EXTERNAL -> Store.EXTERNAL
+        AndroidStore.PADDLE -> Store.PADDLE
     }
 
 public fun Store.toAndroidStore(): AndroidStore =
@@ -27,4 +28,5 @@ public fun Store.toAndroidStore(): AndroidStore =
         Store.AMAZON -> AndroidStore.AMAZON
         Store.RC_BILLING -> AndroidStore.RC_BILLING
         Store.EXTERNAL -> AndroidStore.EXTERNAL
+        Store.PADDLE -> AndroidStore.PADDLE
     }

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/EntitlementInfo.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/EntitlementInfo.ios.kt
@@ -55,6 +55,7 @@ internal fun IosStore.toStore(): Store =
         RCUnknownStore -> Store.UNKNOWN_STORE
         RCAmazon -> Store.AMAZON
         RCBilling -> Store.RC_BILLING
+        RCPaddle -> Store.PADDLE
         else -> error("Unknown IosStore: $this")
     }
 

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/EntitlementInfo.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/EntitlementInfo.kt
@@ -137,6 +137,11 @@ public enum class Store {
      * For entitlements granted via RevenueCat's External Purchases API.
      */
     EXTERNAL,
+
+    /**
+     * For entitlements granted via Paddle.
+     */
+    PADDLE,
 }
 
 /**


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-hybrid-common/pull/1150. Adds the `Paddle` store to KMP.

#### TODO
- [ ] Hold until PHC with changes has been deployed and updated.
- [ ] Update API test files once PHC version has been updated.