### PR TITLE
Enables SNAPSHOT publishing to Maven Central Portal

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,4 +34,4 @@ jetbrains-compose = { id = "org.jetbrains.compose", version = "1.7.0" }
 kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.15.0-Beta.2" }
-vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }
+vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.33.0" }


### PR DESCRIPTION
## Description
Turns out we need at least [0.31.0](https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.31.0) of the `com.vanniktech.maven.publish` to be able to publish SNAPSHOTs to Central Portal. This PR updates to the latest, 0.33.0, same as our other repos.