### PR TITLE
Release/2.0.0+15.0.0

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,17 +1,26 @@
 ## RevenueCat SDK
-### 🐞 Bugfixes
-* Fixes Paywall and Customer Center transition animations on iOS (#427) via JayShortway (@JayShortway)
+This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0
+
+Additionally, we've also updated Kotlin to 2.1.10 and our new minimum version is Kotlin 2.1.0+. If you were using an older version of Kotlin, you will need to update it.
+
+#### Play Billing Library 8: No expired subscriptions or consumed one-time products
+Note: the following is only relevant if you recently integrated RevenueCat, and do not (yet) have all your transactions imported.
+
+Play Billing Library 8 removed functionality to query expired subscriptions or consumed one-time products. This means that, for users migrating from a non-RevenueCat implementation of the Play Billing Library, the SDK will not be able to send purchase information from these purchases. We can still ingest historical data from these purchases through a backend historical import. See [docs](https://www.revenuecat.com/docs/migrating-to-revenuecat/migrating-existing-subscriptions). This doesn't affect developers that have all transactions in RevenueCat, which is true for the vast majority.
+
+#### Using the SDK with your own IAP code (previously Observer Mode)
+Using the SDK with your own IAP code is still supported in v2. Other than updating the SDK version, there are no changes required. Just make sure the version of the Play Billing Library is also version 8.0.0+.
+
+### 💥 Breaking Changes
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 15.0.0 (#448) via RevenueCat Git Bot (@RCGitBot)
+  * [Android 9.1.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.1.0)
+  * [Android 9.0.1](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.1)
+  * [Android 9.0.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.0)
+  * [iOS 5.33.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.33.0)
 ### 📦 Dependency Updates
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 14.2.0 (#439) via RevenueCat Git Bot (@RCGitBot)
-  * [Android 8.22.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.22.0)
-  * [Android 8.21.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.21.0)
-  * [iOS 5.32.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.32.0)
-  * [iOS 5.31.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.31.0)
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 14.1.0 (#437) via RevenueCat Git Bot (@RCGitBot)
-  * [Android 8.22.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.22.0)
-  * [Android 8.21.0](https://github.com/RevenueCat/purchases-android/releases/tag/8.21.0)
-  * [iOS 5.32.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.32.0)
-  * [iOS 5.31.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.31.0)
+* Bump Kotlin to 2.1.10 and JetBrains Compose to 1.8.0 stable (#392) via Jaewoong Eum (@skydoves)
+* [RENOVATE] Update build-dependencies (#445) via RevenueCat Git Bot (@RCGitBot)
 
 ### 🔄 Other Changes
-* Bump danger from 9.5.1 to 9.5.3 (#436) via dependabot[bot] (@dependabot[bot])
+* Add Codelab instruction on the README file (#446) via Jaewoong Eum (@skydoves)
+* Adjusts Renovate setup in line with our other repos. (#444) via JayShortway (@JayShortway)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## 2.0.0+15.0.0
+## RevenueCat SDK
+This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0
+
+Additionally, we've also updated Kotlin to 2.1.10 and our new minimum version is Kotlin 2.1.0+. If you were using an older version of Kotlin, you will need to update it.
+
+#### Play Billing Library 8: No expired subscriptions or consumed one-time products
+Note: the following is only relevant if you recently integrated RevenueCat, and do not (yet) have all your transactions imported.
+
+Play Billing Library 8 removed functionality to query expired subscriptions or consumed one-time products. This means that, for users migrating from a non-RevenueCat implementation of the Play Billing Library, the SDK will not be able to send purchase information from these purchases. We can still ingest historical data from these purchases through a backend historical import. See [docs](https://www.revenuecat.com/docs/migrating-to-revenuecat/migrating-existing-subscriptions). This doesn't affect developers that have all transactions in RevenueCat, which is true for the vast majority.
+
+#### Using the SDK with your own IAP code (previously Observer Mode)
+Using the SDK with your own IAP code is still supported in v2. Other than updating the SDK version, there are no changes required. Just make sure the version of the Play Billing Library is also version 8.0.0+.
+
+### 💥 Breaking Changes
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 15.0.0 (#448) via RevenueCat Git Bot (@RCGitBot)
+  * [Android 9.1.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.1.0)
+  * [Android 9.0.1](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.1)
+  * [Android 9.0.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.0)
+  * [iOS 5.33.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.33.0)
+### 📦 Dependency Updates
+* Bump Kotlin to 2.1.10 and JetBrains Compose to 1.8.0 stable (#392) via Jaewoong Eum (@skydoves)
+* [RENOVATE] Update build-dependencies (#445) via RevenueCat Git Bot (@RCGitBot)
+
+### 🔄 Other Changes
+* Add Codelab instruction on the README file (#446) via Jaewoong Eum (@skydoves)
+* Adjusts Renovate setup in line with our other repos. (#444) via JayShortway (@JayShortway)
+
 ## 1.8.7+14.2.0
 ## RevenueCat SDK
 ### 🐞 Bugfixes

--- a/core/core.podspec
+++ b/core/core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'core'
-    spec.version                  = '1.9.0-SNAPSHOT'
+    spec.version                  = '2.0.0+15.0.0'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ ios-deploymentTarget-ui = "15.0"
 java = "1.8"
 kotlin = "2.1.10"
 revenuecat-common = "15.0.0"
-revenuecat-kmp = "1.9.0-SNAPSHOT"
+revenuecat-kmp = "2.0.0+15.0.0"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/mappings/mappings.podspec
+++ b/mappings/mappings.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'mappings'
-    spec.version                  = '1.9.0-SNAPSHOT'
+    spec.version                  = '2.0.0+15.0.0'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/models/models.podspec
+++ b/models/models.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'models'
-    spec.version                  = '1.9.0-SNAPSHOT'
+    spec.version                  = '2.0.0+15.0.0'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/revenuecatui/revenuecatui.podspec
+++ b/revenuecatui/revenuecatui.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'revenuecatui'
-    spec.version                  = '1.9.0-SNAPSHOT'
+    spec.version                  = '2.0.0+15.0.0'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''


### PR DESCRIPTION
## RevenueCat SDK
This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0

Additionally, we've also updated Kotlin to 2.1.10 and our new minimum version is Kotlin 2.1.0+. If you were using an older version of Kotlin, you will need to update it.

#### Play Billing Library 8: No expired subscriptions or consumed one-time products
Note: the following is only relevant if you recently integrated RevenueCat, and do not (yet) have all your transactions imported.

Play Billing Library 8 removed functionality to query expired subscriptions or consumed one-time products. This means that, for users migrating from a non-RevenueCat implementation of the Play Billing Library, the SDK will not be able to send purchase information from these purchases. We can still ingest historical data from these purchases through a backend historical import. See [docs](https://www.revenuecat.com/docs/migrating-to-revenuecat/migrating-existing-subscriptions). This doesn't affect developers that have all transactions in RevenueCat, which is true for the vast majority.

#### Using the SDK with your own IAP code (previously Observer Mode)
Using the SDK with your own IAP code is still supported in v2. Other than updating the SDK version, there are no changes required. Just make sure the version of the Play Billing Library is also version 8.0.0+.

### 💥 Breaking Changes
* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 15.0.0 (#448) via RevenueCat Git Bot (@RCGitBot)
  * [Android 9.1.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.1.0)
  * [Android 9.0.1](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.1)
  * [Android 9.0.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.0)
  * [iOS 5.33.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.33.0)
### 📦 Dependency Updates
* Bump Kotlin to 2.1.10 and JetBrains Compose to 1.8.0 stable (#392) via Jaewoong Eum (@skydoves)
* [RENOVATE] Update build-dependencies (#445) via RevenueCat Git Bot (@RCGitBot)

### 🔄 Other Changes
* Add Codelab instruction on the README file (#446) via Jaewoong Eum (@skydoves)
* Adjusts Renovate setup in line with our other repos. (#444) via JayShortway (@JayShortway)
