### PR TITLE
Add warning on CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ## 2.0.0+15.0.0
 ## RevenueCat SDK
+
+> [!WARNING]  
+> If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as either consumable or non-consumable. If they're incorrectly configured as consumables, RevenueCat will consume these purchases. This means that users won't be able to restore them from version 9.0.0 onward.
+> Non-consumables are products that are meant to be bought only once, for example, lifetime subscriptions.
+
 This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0
 
 Additionally, we've also updated Kotlin to 2.1.10 and our new minimum version is Kotlin 2.1.0+. If you were using an older version of Kotlin, you will need to update it.


### PR DESCRIPTION
Some users have been facing issues on the latest major migration when using anonymous accounts and haven't configured their one time products correctly in the RevenueCat dashboard. This adds a warning to the changelog in an effort to make this issue a bit more visible before upgrading.
