### PR TITLE
Migrates to `kotlin.time.Instant` from the stdlib

### DIFF
--- a/datetime/build.gradle.kts
+++ b/datetime/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            api(libs.kotlinx.datetime)
             implementation(projects.core)
         }
     }

--- a/datetime/src/commonMain/kotlin/com/revenuecat/purchases/kmp/datetime/CustomerInfo.kt
+++ b/datetime/src/commonMain/kotlin/com/revenuecat/purchases/kmp/datetime/CustomerInfo.kt
@@ -2,13 +2,15 @@ package com.revenuecat.purchases.kmp.datetime
 
 import com.revenuecat.purchases.kmp.Purchases
 import com.revenuecat.purchases.kmp.models.CustomerInfo
-import kotlinx.datetime.Instant
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Map of productIds to expiration instants.
  *  * For Google subscriptions, productIds are `subscriptionId:basePlanId`.
  *  * For Amazon subscriptions, productsIds are `termSku`.
  */
+@OptIn(ExperimentalTime::class)
 public val CustomerInfo.allExpirationInstants: Map<String, Instant?>
     get() = allExpirationDateMillis.mapValues { (_, millis) ->
         millis?.let { Instant.fromEpochMilliseconds(it) }
@@ -20,6 +22,7 @@ public val CustomerInfo.allExpirationInstants: Map<String, Instant?>
  *  * For Google and Amazon INAPPs, productsIds are simply `productId`.
  *  * For Amazon subscriptions, productsIds are `termSku`.
  */
+@OptIn(ExperimentalTime::class)
 public val CustomerInfo.allPurchaseInstants: Map<String, Instant?>
     get() = allPurchaseDateMillis.mapValues { (_, millis) ->
         millis?.let { Instant.fromEpochMilliseconds(it) }
@@ -28,12 +31,14 @@ public val CustomerInfo.allPurchaseInstants: Map<String, Instant?>
 /**
  * The instant this user was first seen in RevenueCat.
  */
+@OptIn(ExperimentalTime::class)
 public val CustomerInfo.firstSeenInstant: Instant
     get() = Instant.fromEpochMilliseconds(firstSeenMillis)
 
 /**
  * The latest expiration instant of all purchased productIds.
  */
+@OptIn(ExperimentalTime::class)
 public val CustomerInfo.latestExpirationInstant: Instant?
     get() = latestExpirationDateMillis?.let { Instant.fromEpochMilliseconds(it) }
 
@@ -42,11 +47,13 @@ public val CustomerInfo.latestExpirationInstant: Instant?
  * for grandfathering users when migrating to subscriptions. This can be null, see
  * [Purchases.restorePurchases].
  */
+@OptIn(ExperimentalTime::class)
 public val CustomerInfo.originalPurchaseInstant: Instant?
     get() = originalPurchaseDateMillis?.let { Instant.fromEpochMilliseconds(it) }
 
 /**
  * The instant when this info was requested.
  */
+@OptIn(ExperimentalTime::class)
 public val CustomerInfo.requestInstant: Instant
     get() = Instant.fromEpochMilliseconds(requestDateMillis)

--- a/datetime/src/commonMain/kotlin/com/revenuecat/purchases/kmp/datetime/EntitlementInfo.kt
+++ b/datetime/src/commonMain/kotlin/com/revenuecat/purchases/kmp/datetime/EntitlementInfo.kt
@@ -2,18 +2,21 @@ package com.revenuecat.purchases.kmp.datetime
 
 import com.revenuecat.purchases.kmp.models.EntitlementInfo
 import com.revenuecat.purchases.kmp.models.PeriodType
-import kotlinx.datetime.Instant
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 
 /**
  * Nullable on iOS only not on Android. The latest purchase or renewal instant for the entitlement.
  */
+@OptIn(ExperimentalTime::class)
 public val EntitlementInfo.latestPurchaseInstant: Instant?
     get() = latestPurchaseDateMillis?.let { Instant.fromEpochMilliseconds(it) }
 
 /**
  * Nullable on iOS only not on Android. The first instant this entitlement was purchased.
  */
+@OptIn(ExperimentalTime::class)
 public val EntitlementInfo.originalPurchaseInstant: Instant?
     get() = originalPurchaseDateMillis?.let { Instant.fromEpochMilliseconds(it) }
 
@@ -21,6 +24,7 @@ public val EntitlementInfo.originalPurchaseInstant: Instant?
  * The expiration instant for the entitlement, can be `null` for lifetime access. If the
  * [periodType] is [PeriodType.TRIAL], this is the trial expiration instant.
  */
+@OptIn(ExperimentalTime::class)
 public val EntitlementInfo.expirationInstant: Instant?
     get() = expirationDateMillis?.let { Instant.fromEpochMilliseconds(it) }
 
@@ -30,6 +34,7 @@ public val EntitlementInfo.expirationInstant: Instant?
  * Note: Entitlement may still be active even if user has unsubscribed. Check the [isActive]
  * property.
  */
+@OptIn(ExperimentalTime::class)
 public val EntitlementInfo.unsubscribeDetectedAtInstant: Instant?
     get() = unsubscribeDetectedAtMillis?.let { Instant.fromEpochMilliseconds(it) }
 
@@ -38,5 +43,6 @@ public val EntitlementInfo.unsubscribeDetectedAtInstant: Instant?
  * has been resolved. Note: Entitlement may still be active even if there is a billing issue.
  * Check the [isActive] property.
  */
+@OptIn(ExperimentalTime::class)
 public val EntitlementInfo.billingIssueDetectedAtInstant: Instant?
     get() = billingIssueDetectedAtMillis?.let { Instant.fromEpochMilliseconds(it) }

--- a/datetime/src/commonMain/kotlin/com/revenuecat/purchases/kmp/datetime/Transaction.kt
+++ b/datetime/src/commonMain/kotlin/com/revenuecat/purchases/kmp/datetime/Transaction.kt
@@ -1,10 +1,12 @@
 package com.revenuecat.purchases.kmp.datetime
 
 import com.revenuecat.purchases.kmp.models.Transaction
-import kotlinx.datetime.Instant
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * The purchase instant.
  */
+@OptIn(ExperimentalTime::class)
 public val Transaction.purchaseInstant: Instant
     get() = Instant.fromEpochMilliseconds(purchaseDateMillis)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ android-targetSdk = "35"
 ios-deploymentTarget-core = "13.0"
 ios-deploymentTarget-ui = "15.0"
 java = "1.8"
-kotlin = "2.1.10"
+kotlin = "2.1.20"
 revenuecat-common = "16.2.0"
 revenuecat-kmp = "2.2.0-SNAPSHOT"
 


### PR DESCRIPTION
## Description

The `Instant` (and `Clock`) types [are moving](https://github.com/Kotlin/kotlinx-datetime?tab=readme-ov-file#deprecation-of-instant) from the kotlinx-datetime library to Kotlin's stdlib. They're available since Kotlin 2.1.20. Concretely this means that `kotlinx.datetime.Instant` is deprecated and replaced by `kotlin.time.Instant`. This PR makes use of the new type, and removes the kotlinx-datetime dependency (because we don't use anything else). 

This is technically a breaking change, but the kotlinx-datetime library is still experimental in its entirety. This will only affect devs using that experimental library already. 

The alternative is to bump the version of the kotlinx-datetime library to 0.7.1, which is a compatibility release still containing the deprecated types, but that's just delays the inevitable. Happy to hear thoughts.

Closes #468 
