### PR TITLE
Fixes a potential crash on Android when calling `purchase()` in rapid succession

### DIFF
--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/di/AndroidProvider.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/di/AndroidProvider.kt
@@ -38,7 +38,17 @@ internal object AndroidProvider : Application.ActivityLifecycleCallbacks {
     }
 
     override fun onActivityPaused(activity: Activity) {
-        if (activity == AndroidProvider.activity) AndroidProvider.activity = null
+        // Noop
+        //
+        // If we were to set AndroidProvider.activity to null here, calling purchase() twice in
+        // rapid succession would crash because the second invocation of purchase() would find a
+        // null activity.
+        //
+        // If we leave AndroidProvider.activity set to the paused activity, the second invocation of
+        // purchase() will return an OperationAlreadyInProgressError as expected, and doesn't crash.
+        //
+        // In the purchase flow, onActivityCreated will be called right after onActivityPaused with
+        // the ProxyBillingActivity, which will then be set as the current activity.
     }
 
     override fun onActivityStopped(activity: Activity) {
@@ -50,6 +60,7 @@ internal object AndroidProvider : Application.ActivityLifecycleCallbacks {
     }
 
     override fun onActivityDestroyed(activity: Activity) {
+        println("TESTING onActivityDestroyed called with $activity, current activity is ${AndroidProvider.activity}")
         if (activity == AndroidProvider.activity) AndroidProvider.activity = null
     }
 }

--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/di/AndroidProvider.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/di/AndroidProvider.kt
@@ -60,7 +60,6 @@ internal object AndroidProvider : Application.ActivityLifecycleCallbacks {
     }
 
     override fun onActivityDestroyed(activity: Activity) {
-        println("TESTING onActivityDestroyed called with $activity, current activity is ${AndroidProvider.activity}")
         if (activity == AndroidProvider.activity) AndroidProvider.activity = null
     }
 }


### PR DESCRIPTION
## Bug
The app would sometimes crash when calling `purchase()`, complaining that there's no current Activity.

## Cause
This would happen when calling `purchase()` in rapid succession. Here's the timeline of what would happen:
1. `purchase()`
2. `onActivityPaused()` --> Sets `ActivityProvider.activity` to null
3. A few milliseconds pass. If we call `purchase()` during this time, we crash. If we don't, we go to the next step.
4. `onActivityCreated()` --> Sets `ActivityProvider.activity` to `ProxyBillingActivity`

## Fix
The fix is to not set the current Activity to null in `onActivityPaused()`. For all intents and purposes a paused Activity can still be considered the "current" Activity, until a new one is created. 

This avoids the crash, and makes the second invocation of `purchase()` return the expected `OperationAlreadyInProgressError`. Here's the new timeline:

1. `purchase()`
2. `onActivityPaused()` --> Nothing happens.`ActivityProvider.activity` is still set to the paused Activity.
3. A few milliseconds pass. If we call `purchase()` during this time, we return `OperationAlreadyInProgressError` as expected. If we don't, we go to the next step. In either case, the user won't notice this.
4. `onActivityCreated()` --> Sets `ActivityProvider.activity` to `ProxyBillingActivity`


Closes #504 and https://community.revenuecat.com/sdks-51/app-crashes-on-android-when-making-a-purchase-with-kotlin-multiplatform-sdk-6902.