### PR TITLE
[v1] Prepare for next release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,6 +474,8 @@ workflows:
         - matches: { pattern: "^release/.+$", value: << pipeline.git.branch >> }
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - not:
+            equal: [ bump, << pipeline.parameters.action >> ]
     jobs:
       - detekt
       - build-libraries-android

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 7d97553e9c5baabcd18286f03d8034797a27dd64
+  revision: 1593f78d0b9b24b48238337666183e3ba82f848e
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri
@@ -269,7 +269,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0617)
+    mime-types-data (3.2025.0924)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)
@@ -282,9 +282,9 @@ GEM
     naturally (2.3.0)
     netrc (0.11.0)
     nkf (0.2.0)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux-gnu)
+    nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (10.0.0)
       faraday (>= 1, < 3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,7 +54,8 @@ desc "Automatically determines next version, bumps it, edits changelog, and crea
 lane :automatic_bump do |options|
   next_version, type_of_bump = determine_next_version_using_labels(
     repo_name: REPO_NAME,
-    github_rate_limit: options[:github_rate_limit]
+    github_rate_limit: options[:github_rate_limit],
+    current_version: current_version_number
   )
   options[:next_version] = next_version
   options[:automatic_release] = true


### PR DESCRIPTION
This PR makes the changes needed for the next release of v1.

* Bump [fastlane-plugin-revenuecat_internal](https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal) from `7d97553 ` to `1593f78`. See full diff in <a href="https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/compare/7d97553e9c5baabcd18286f03d8034797a27dd64...1593f78d0b9b24b48238337666183e3ba82f848e">compare view</a>.
* Pass current version in automatic bump.
* [CI] `bump` pipeline action won't trigger `on-release-branch` workflow.