### PR TITLE
Update Gradle wrapper-validation to 4 for the `dependency-submission` GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v4
-    - uses: gradle/wrapper-validation-action@v2
+    - uses: gradle/actions/wrapper-validation@v4
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
## Description
Follow-up of https://github.com/RevenueCat/purchases-kmp/pull/494 for the `dependency-submission` GitHub Action, which has also [been failing](https://github.com/RevenueCat/purchases-kmp/actions/runs/18103475976/job/51512156080).