### PR TITLE
Adds purchases-ios as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "upstream/purchases-ios"]
 	path = upstream/purchases-ios
 	url = git@github.com:RevenueCat/purchases-ios.git
+	branch = 5.39.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "upstream/purchases-ios"]
+	path = upstream/purchases-ios
+	url = git@github.com:RevenueCat/purchases-ios.git

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>RevenueCat/renovate"]
+  "extends": ["github>RevenueCat/renovate"],
+  "git-submodules": {
+    "enabled": true,
+    "versioning": "semver"
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
   "git-submodules": {
     "enabled": true,
     "versioning": "semver"
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["git-submodules"],
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
## Motivation
We want to improve the developer experience (both for app developers and ourselves) of purchases-kmp, by removing the need to manually declare the PHC dependency in the iOS app. We will instead embed purchases-ios statically in the shipped `.klib`.

## Description
We'll do this incrementally. This is the first of many steps. It just adds purchases-ios as a submodule, but it's still unused. Later steps will make sure the purchases-ios source code gets compiled as part of the build, and included in the `.klib`.

- Adds purchases-ios as git submodule.
- Adds a Renovate config to keep it updated.

I purposefully did not set purchases-ios to the latest version, because I want to see if the Renovate config works. Renovate is kinda hard to test until it's all on `main`. We won't be using the submodule for a while yet, so we have some time to figure this out. 