### PR TITLE
Updates VCS mapping to include `upstream/purchases-ios`

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -12,5 +12,6 @@
   </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/upstream/purchases-ios" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
## Description
Super quick one. This allows Android Studio to recognize the `upstream/purchases-ios` folder as a git repo, enabling Android Studio's regular git operations.