### PR TITLE
Allows declaring `swiftPackage` dependencies

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/plugin/RevenueCatLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/plugin/RevenueCatLibraryConventionPlugin.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.kmp.buildlogic.plugin
 
 import com.revenuecat.purchases.kmp.buildlogic.convention.configureAndroid
 import com.revenuecat.purchases.kmp.buildlogic.convention.configureKotlin
+import com.revenuecat.purchases.kmp.buildlogic.swift.configureSwiftDependencies
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -24,6 +25,7 @@ class RevenueCatLibraryConventionPlugin : Plugin<Project> {
 
         configureKotlin()
         configureAndroid()
+        configureSwiftDependencies()
 
         // Disable dokka if needed.
         afterEvaluate {

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
@@ -1,0 +1,314 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift
+
+import com.revenuecat.purchases.kmp.buildlogic.swift.model.SwiftDependency
+import com.revenuecat.purchases.kmp.buildlogic.swift.model.getSwiftPackageInfo
+import com.revenuecat.purchases.kmp.buildlogic.swift.task.GenerateDefFileTask
+import com.revenuecat.purchases.kmp.buildlogic.swift.task.SwiftBuildTask
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.KonanTarget
+import java.io.File
+
+/**
+ * Registers the Swift package registry and configures Swift dependencies.
+ */
+fun Project.configureSwiftDependencies() {
+    val registry = getOrCreateSwiftPackageRegistry()
+
+    afterEvaluate {
+        if (registry.packages.isNotEmpty()) {
+            configureAllSwiftDependencies(registry.packages)
+        }
+    }
+}
+
+private fun Project.configureAllSwiftDependencies(dependencies: List<SwiftDependency>) {
+    val kotlin = extensions.findByType(KotlinMultiplatformExtension::class.java)
+        ?: error("Kotlin Multiplatform plugin must be applied before configuring Swift dependencies")
+
+    // Group dependencies by packageDir to avoid running `swift package describe` multiple times
+    val dependenciesByPackageDir = dependencies.groupBy { it.packageDir }
+
+    // We need to find the source directory of each Swift target.
+    val targetSourceDirs = mutableMapOf<SwiftDependency, File>()
+    val targetSwiftDependencies = mutableMapOf<SwiftDependency, List<String>>()
+    
+    dependenciesByPackageDir.forEach { (packageDir, deps) ->
+        val packageInfo = getSwiftPackageInfo(packageDir)
+        deps.forEach { dep ->
+            targetSourceDirs[dep] = packageInfo.getTargetSourceDir(dep.target, packageDir)
+            targetSwiftDependencies[dep] = packageInfo.getTargetDependencies(dep.target)
+        }
+    }
+
+    dependencies.forEach { dependency ->
+        val targetSourceDir = targetSourceDirs[dependency]
+            ?: error("Could not resolve source directory for target ${dependency.target}")
+        val swiftDependencies = targetSwiftDependencies[dependency] ?: emptyList()
+        configureSwiftDependency(kotlin, dependency, targetSourceDir, swiftDependencies)
+    }
+}
+
+private fun Project.configureSwiftDependency(
+    kotlin: KotlinMultiplatformExtension,
+    dependency: SwiftDependency,
+    targetSourceDir: File,
+    swiftDependencies: List<String>
+) {
+    // Register a task to generate the cinterop .def file
+    val defFile = layout.buildDirectory.file("generated/cinterop/${dependency.target}.def")
+    val generateDefTaskName = "generateCinteropDef${dependency.target}"
+    val generateDefTask = tasks.register(generateDefTaskName, GenerateDefFileTask::class.java) {
+        packageName.set(dependency.packageName)
+        moduleName.set(dependency.moduleName)
+        libraryName.set(dependency.libraryName)
+        dependency.customDeclarations?.let { customDeclarations.set(it) }
+        this.toolchainPath.set(getToolchainPath())
+        this.swiftSourceDir.set(targetSourceDir)
+        this.defFile.set(defFile)
+    }
+
+    // Find which Swift dependencies are owned by other projects
+    val globalRegistry = getOrCreateGlobalSwiftRegistry()
+    val moduleDependencies = swiftDependencies.mapNotNull { depTarget ->
+        globalRegistry.findOwner(depTarget)
+            // Only include dependencies from other projects
+            ?.takeIf { it.project != this  }
+    }
+
+    kotlin.targets.withType<KotlinNativeTarget> {
+        // Skip this target if it doesn't include the source set this dependency is added to.
+        if (!includesSourceSet(dependency.sourceSetName)) return@withType
+
+        if (!konanTarget.isAppleTarget()) error(
+            "swiftPackage() was called from source set '${dependency.sourceSetName}', " +
+                    "but only Apple targets are supported."
+        )
+
+        val mainCompilation = compilations.getByName("main")
+        val swiftBuildTask = registerSwiftBuildTask(this, dependency, targetSourceDir)
+        val swiftOutputDir = layout.buildDirectory
+            .dir("swift-packages/${dependency.target}/${konanTarget.name}")
+            .get().asFile
+
+        val sdkPath = getSdkPath(konanTarget)
+
+        // Collect module paths: our own output + outputs from Swift dependencies in other projects
+        val dependencyModulePaths = moduleDependencies.map { dep ->
+            dep.project.layout.buildDirectory
+                .dir("swift-packages/${dep.dependency.target}/${konanTarget.name}")
+                .get().asFile
+        }
+        val allModulePaths = listOf(swiftOutputDir) + dependencyModulePaths
+
+        mainCompilation.cinterops.create(dependency.target) {
+            defFile(defFile)
+            extraOpts("-libraryPath", swiftOutputDir.absolutePath)
+
+            // Add -I flags for all module paths (own + dependencies)
+            compilerOpts(
+                "-fmodules",
+                "-isysroot", sdkPath,
+                *allModulePaths.flatMap { listOf("-I", it.absolutePath) }.toTypedArray()
+            )
+
+            tasks.named(interopProcessingTaskName).configure {
+                // Make sure we generate the .def file and compile Swift before cinterop runs.
+                dependsOn(generateDefTask)
+                dependsOn(swiftBuildTask)
+
+                // We're not configuring the static library as input because somehow it causes build 
+                // failures when building debug after release (e.g. publishToMavenLocal). It seems to 
+                // have something to do with the cinterop commonizer.
+                // As a workaround we're adding the static library's checksum to the def file in GenerateDefFileTask.
+                // This has the same effect of picking up any changes in Swift regardless of whether they're public.
+
+                // Add task dependencies for Swift builds from other projects
+                moduleDependencies.forEach { dep ->
+                    val taskSuffix = getTaskSuffix(konanTarget)
+                    val depTaskName = "compileSwift${dep.dependency.target}$taskSuffix"
+                    dependsOn(dep.project.tasks.named(depTaskName))
+                }
+            }
+        }
+    }
+}
+
+private fun KonanTarget.isAppleTarget(): Boolean =
+    this in listOf(
+        // iOS
+        KonanTarget.IOS_ARM64,
+        KonanTarget.IOS_SIMULATOR_ARM64,
+        KonanTarget.IOS_X64,
+        // macOS
+        KonanTarget.MACOS_ARM64,
+        KonanTarget.MACOS_X64,
+        // tvOS
+        KonanTarget.TVOS_ARM64,
+        KonanTarget.TVOS_SIMULATOR_ARM64,
+        KonanTarget.TVOS_X64,
+        // watchOS
+        KonanTarget.WATCHOS_ARM64,
+        KonanTarget.WATCHOS_SIMULATOR_ARM64,
+        KonanTarget.WATCHOS_X64,
+        KonanTarget.WATCHOS_DEVICE_ARM64,
+    )
+
+/**
+ * Determines if a target should include a source set based on Kotlin Multiplatform naming
+ * conventions.
+ */
+private fun KotlinNativeTarget.includesSourceSet(sourceSetName: String): Boolean {
+    val targetName = this.name
+
+    if (sourceSetName == "${targetName}Main") return true
+
+    return when (sourceSetName) {
+        "appleMain" -> targetName.startsWith("ios") ||
+                targetName.startsWith("macos") ||
+                targetName.startsWith("tvos") ||
+                targetName.startsWith("watchos")
+
+        "iosMain" -> targetName.startsWith("ios")
+        "macosMain" -> targetName.startsWith("macos")
+        "tvosMain" -> targetName.startsWith("tvos")
+        "watchosMain" -> targetName.startsWith("watchos")
+        else -> false
+    }
+}
+
+private fun Project.registerSwiftBuildTask(
+    kotlinTarget: KotlinNativeTarget,
+    dependency: SwiftDependency,
+    targetSourceDir: File
+): TaskProvider<SwiftBuildTask> {
+    val taskSuffix = getTaskSuffix(kotlinTarget.konanTarget)
+    val taskName = "compileSwift${dependency.target}$taskSuffix"
+
+    return tasks.register(taskName, SwiftBuildTask::class.java) {
+        swiftTarget.set(dependency.target)
+        sdk.set(kotlinTarget.konanTarget.getSdkName())
+        triple.set(kotlinTarget.konanTarget.getTriple())
+        headerName.set(dependency.headerName)
+        libraryName.set(dependency.libraryName)
+        moduleName.set(dependency.moduleName)
+        configuration.set(getSwiftConfiguration())
+        packageDir.set(dependency.packageDir)
+        this.targetSourceDir.set(targetSourceDir)
+        outputDir.set(layout.buildDirectory.dir("swift-packages/${dependency.target}/${kotlinTarget.konanTarget.name}"))
+        // Use a shared scratch directory at root project level for SPM build cache sharing
+        scratchDir.set(rootProject.layout.buildDirectory.dir("swift-packages/.build"))
+    }
+}
+
+/**
+ * Get the task name suffix for a given Konan target.
+ */
+private fun getTaskSuffix(konanTarget: KonanTarget): String = when (konanTarget) {
+    // iOS
+    KonanTarget.IOS_ARM64 -> "IosArm64"
+    KonanTarget.IOS_SIMULATOR_ARM64 -> "IosSimulatorArm64"
+    KonanTarget.IOS_X64 -> "IosX64"
+    // macOS
+    KonanTarget.MACOS_ARM64 -> "MacosArm64"
+    KonanTarget.MACOS_X64 -> "MacosX64"
+    // tvOS
+    KonanTarget.TVOS_ARM64 -> "TvosArm64"
+    KonanTarget.TVOS_SIMULATOR_ARM64 -> "TvosSimulatorArm64"
+    KonanTarget.TVOS_X64 -> "TvosX64"
+    // watchOS
+    KonanTarget.WATCHOS_ARM64 -> "WatchosArm64"
+    KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "WatchosSimulatorArm64"
+    KonanTarget.WATCHOS_X64 -> "WatchosX64"
+    KonanTarget.WATCHOS_DEVICE_ARM64 -> "WatchosDeviceArm64"
+    else -> error("Unexpected target: $konanTarget")
+}
+
+/**
+ * Determines the Swift build configuration to use.
+ *
+ * Priority:
+ * 1. Explicit `-PswiftConfiguration=debug|release` property
+ * 2. Xcode's CONFIGURATION environment variable
+ * 3. `release` if any publishing tasks are being run
+ * 4. `debug` otherwise, for incremental builds during local development
+ */
+private fun Project.getSwiftConfiguration(): String {
+    val override = findProperty("swiftConfiguration")?.toString()
+    if (override != null) {
+        require(override in listOf("debug", "release")) {
+            "swiftConfiguration must be 'debug' or 'release', got: $override"
+        }
+        return override
+    }
+
+    val xcodeConfig = providers.environmentVariable("CONFIGURATION").orNull
+    if (xcodeConfig != null) {
+        return when (xcodeConfig.lowercase()) {
+            "debug" -> "debug"
+            "release" -> "release"
+            else -> "release"
+        }
+    }
+
+    val taskNames = gradle.startParameter.taskNames
+    val isPublishing = taskNames.any { it.contains("publish", ignoreCase = true) }
+    if (isPublishing) return "release"
+
+    return "debug"
+}
+
+private fun Project.getToolchainPath(): Provider<String?> =
+    providers.exec {
+        commandLine("xcrun", "--find", "swift")
+    }.standardOutput.asText.map { swiftPath ->
+        // swift is at .../Toolchains/XcodeDefault.xctoolchain/usr/bin/swift
+        // but we need .../Toolchains/XcodeDefault.xctoolchain
+        File(swiftPath.trim()).parentFile.parentFile.absolutePath
+    }
+
+private fun Project.getSdkPath(konanTarget: KonanTarget): String =
+    getSdkPath(sdk = konanTarget.getSdkName())
+
+private fun Project.getSdkPath(sdk: String): String =
+    providers.exec {
+        commandLine("xcrun", "--sdk", sdk, "--show-sdk-path")
+    }.standardOutput.asText.get().trim()
+
+private fun KonanTarget.getSdkName(): String = when (this) {
+    // iOS
+    KonanTarget.IOS_X64, KonanTarget.IOS_SIMULATOR_ARM64 -> "iphonesimulator"
+    KonanTarget.IOS_ARM64 -> "iphoneos"
+    // macOS
+    KonanTarget.MACOS_ARM64, KonanTarget.MACOS_X64 -> "macosx"
+    // tvOS
+    KonanTarget.TVOS_X64, KonanTarget.TVOS_SIMULATOR_ARM64 -> "appletvsimulator"
+    KonanTarget.TVOS_ARM64 -> "appletvos"
+    // watchOS
+    KonanTarget.WATCHOS_X64, KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "watchsimulator"
+    KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_DEVICE_ARM64 -> "watchos"
+    else -> error("Unsupported target: ${this}")
+}
+
+private fun KonanTarget.getTriple(): String = when (this) {
+    // iOS
+    KonanTarget.IOS_X64 -> "x86_64-apple-ios-simulator"
+    KonanTarget.IOS_SIMULATOR_ARM64 -> "arm64-apple-ios-simulator"
+    KonanTarget.IOS_ARM64 -> "arm64-apple-ios"
+    // macOS
+    KonanTarget.MACOS_X64 -> "x86_64-apple-macosx"
+    KonanTarget.MACOS_ARM64 -> "arm64-apple-macosx"
+    // tvOS
+    KonanTarget.TVOS_X64 -> "x86_64-apple-tvos-simulator"
+    KonanTarget.TVOS_SIMULATOR_ARM64 -> "arm64-apple-tvos-simulator"
+    KonanTarget.TVOS_ARM64 -> "arm64-apple-tvos"
+    // watchOS
+    KonanTarget.WATCHOS_X64 -> "x86_64-apple-watchos-simulator"
+    KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "arm64-apple-watchos-simulator"
+    KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_DEVICE_ARM64 -> "arm64-apple-watchos"
+    else -> error("Unsupported target: $this")
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/GlobalSwiftPackageRegistry.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/GlobalSwiftPackageRegistry.kt
@@ -1,0 +1,65 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift
+
+import com.revenuecat.purchases.kmp.buildlogic.swift.model.SwiftDependency
+import org.gradle.api.Project
+
+/**
+ * A global registry that tracks all Swift targets declared across all Gradle projects.
+ * This is mainly used to auto-detect module dependencies between Swift targets.
+ *
+ * This registry is created on the root project and accessed by all subprojects.
+ */
+open class GlobalSwiftPackageRegistry {
+    /**
+     * All registered Swift targets, keyed by target name.
+     * Each entry contains the owning project and the dependency configuration.
+     */
+    internal val targets = mutableMapOf<String, RegisteredSwiftTarget>()
+
+    /**
+     * A registered Swift target and its owning project.
+     */
+    internal data class RegisteredSwiftTarget(
+        val project: Project,
+        val dependency: SwiftDependency
+    )
+
+    /**
+     * Register a Swift target.
+     * @param target The Swift target name
+     * @param project The Gradle project that owns this target
+     * @param dependency The dependency configuration
+     */
+    internal fun register(target: String, project: Project, dependency: SwiftDependency) {
+        val existing = targets[target]
+        if (existing != null && existing.project != project) {
+            error(
+                "Swift target '$target' is declared in multiple projects: " +
+                        "'${existing.project.path}' and '${project.path}'. " +
+                        "Each Swift target should be owned by exactly one Gradle project."
+            )
+        }
+        targets[target] = RegisteredSwiftTarget(project, dependency)
+    }
+
+    /**
+     * Get all registered targets.
+     */
+    internal fun getAllTargets(): Map<String, RegisteredSwiftTarget> = targets.toMap()
+
+    /**
+     * Find which project owns a given target, if any.
+     */
+    internal fun findOwner(targetName: String): RegisteredSwiftTarget? = targets[targetName]
+}
+
+/**
+ * Get or create the global Swift package registry on the root project.
+ */
+internal fun Project.getOrCreateGlobalSwiftRegistry(): GlobalSwiftPackageRegistry {
+    return rootProject.extensions.findByType(GlobalSwiftPackageRegistry::class.java)
+        ?: rootProject.extensions.create(
+            "globalSwiftPackageRegistry",
+            GlobalSwiftPackageRegistry::class.java
+        )
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/SwiftPackageExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/SwiftPackageExtensions.kt
@@ -1,0 +1,87 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift
+
+import com.revenuecat.purchases.kmp.buildlogic.swift.model.SwiftDependency
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import java.io.File
+
+/**
+ * This is used to collect all Swift package dependencies declared via [swiftPackage].
+ */
+open class SwiftPackageRegistry {
+    internal val packages = mutableListOf<SwiftDependency>()
+
+    internal fun add(dependency: SwiftDependency) {
+        packages.add(dependency)
+    }
+}
+
+/**
+ * Adds a Swift package dependency to the project.
+ *
+ * This function should be called in a dependencies block of a Kotlin source set belonging to an
+ * Apple target, such as `iosMain`.
+ *
+ * @param path Path to the Swift package directory (containing `Package.swift`) or to the
+ * `Package.swift` file itself.
+ * @param target The Swift target name to build and generate bindings for.
+ * @param packageName The Kotlin package name for the generated cinterop bindings.
+ * @param customDeclarations Optional declarations to include in the .def file. Use this to force
+ * cinterop binding generation for types not otherwise referenced in the public API of the Swift
+ * [target].
+ */
+fun KotlinDependencyHandler.swiftPackage(
+    path: File,
+    target: String,
+    packageName: String,
+    customDeclarations: String? = null
+) {
+    val registry = project.extensions.findByType(SwiftPackageRegistry::class.java)
+        ?: error(
+            "SwiftPackageRegistry not found. Make sure the `revenuecat-library` plugin is " +
+                    "applied before using `swiftPackage()`."
+        )
+    
+    val sourceSetName = getSourceSetName()
+    val dependency = SwiftDependency(
+        packagePath = path,
+        target = target,
+        packageName = packageName,
+        sourceSetName = sourceSetName,
+        customDeclarations = customDeclarations
+    )
+    registry.add(dependency)
+    
+    // Also register to the global registry for cross-project dependency detection
+    val globalRegistry = project.getOrCreateGlobalSwiftRegistry()
+    globalRegistry.register(target, project, dependency)
+}
+
+private fun KotlinDependencyHandler.getSourceSetName(): String {
+    var current: Class<*>? = this.javaClass
+    while (current != null && current != Any::class.java) {
+        for (field in current.declaredFields) {
+            try {
+                field.isAccessible = true
+                val value = field.get(this)
+                if (value is KotlinSourceSet) {
+                    return value.name
+                }
+            } catch (_: Exception) {
+                // Continue to next field
+            }
+        }
+        current = current.superclass
+    }
+
+    error(
+        "Could not determine source set for swiftPackage(). " +
+        "This might be due to a Kotlin Gradle Plugin version incompatibility. "
+    )
+}
+
+internal fun Project.getOrCreateSwiftPackageRegistry(): SwiftPackageRegistry {
+    return extensions.findByType(SwiftPackageRegistry::class.java)
+        ?: extensions.create("swiftPackageRegistry", SwiftPackageRegistry::class.java)
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/model/SwiftDependency.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/model/SwiftDependency.kt
@@ -1,0 +1,35 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift.model
+
+import java.io.File
+
+/**
+ * Configuration for a Swift dependency.
+ *
+ * @param packagePath Path to either the Package.swift file or the directory containing it
+ * @param target The Swift target name (e.g., "RevenueCat" or "RevenueCatUI")
+ * @param packageName The Kotlin package name for the generated cinterop bindings
+ * @param sourceSetName The Kotlin source set this dependency was declared in (e.g., "iosMain")
+ * @param customDeclarations Optional declarations to force cinterop binding generation
+ */
+internal class SwiftDependency(
+    packagePath: File,
+    val target: String,
+    val packageName: String,
+    val sourceSetName: String,
+    val customDeclarations: String? = null
+) {
+    /**
+     * Directory containing the Package.swift file (used as working directory for swift build).
+     * Resolved from [packagePath] - if it points to a Package.swift file, uses its parent directory.
+     */
+    val packageDir: File = if (packagePath.name == "Package.swift") {
+        packagePath.parentFile
+    } else {
+        packagePath
+    }
+
+    // Derived properties computed from the target name
+    val headerName: String get() = "$target-Swift.h"
+    val libraryName: String get() = "lib$target.a"
+    val moduleName: String get() = target
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/model/SwiftPackageInfo.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/model/SwiftPackageInfo.kt
@@ -1,0 +1,84 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift.model
+
+import groovy.json.JsonSlurper
+import org.gradle.api.Project
+import java.io.File
+
+
+/**
+ * Runs `swift package describe --type json` and parses the output.
+ */
+internal fun Project.getSwiftPackageInfo(packageDir: File): SwiftPackageInfo {
+    val result = providers.exec {
+        workingDir = packageDir
+        commandLine("xcrun", "swift", "package", "describe", "--type", "json")
+        isIgnoreExitValue = true
+        // Avoids trying to use the iOS SDK to parse the Package.swift when building from Xcode.
+        // This environment change is scoped to this subprocess only.
+        environment("SDKROOT", "")
+    }
+
+    val exitCode = result.result.get().exitValue
+    if (exitCode != 0) {
+        val stderr = result.standardError.asText.get()
+        error("Failed to run 'swift package describe' in $packageDir (exit code $exitCode): $stderr")
+    }
+
+    val output = result.standardOutput.asText.get()
+    return SwiftPackageInfo.parse(output)
+}
+
+/**
+ * Parsed information from `swift package describe --type json`.
+ */
+internal class SwiftPackageInfo(
+    private val targets: List<TargetInfo>
+) {
+    data class TargetInfo(
+        val name: String,
+        val path: String?,
+        val targetDependencies: List<String>
+    )
+
+    fun getTargetSourceDir(targetName: String, packageDir: File): File {
+        val target = targets.find { it.name == targetName }
+            ?: error("Target '$targetName' not found in Package.swift. Available targets: ${targets.map { it.name }}")
+
+        val relativePath = target.path ?: "Sources/$targetName"
+        return packageDir.resolve(relativePath)
+    }
+
+    /**
+     * Get the list of target dependencies for a given target.
+     */
+    fun getTargetDependencies(targetName: String): List<String> {
+        val target = targets.find { it.name == targetName }
+            ?: error("Target '$targetName' not found in Package.swift. Available targets: ${targets.map { it.name }}")
+        return target.targetDependencies
+    }
+
+    companion object {
+
+        /**
+         * Parses output from `swift package describe --type json` into a [SwiftPackageInfo].
+         */
+        @Suppress("UNCHECKED_CAST")
+        fun parse(json: String): SwiftPackageInfo {
+            val parsed = JsonSlurper().parseText(json) as Map<String, Any>
+            val targetsJson = parsed["targets"] as? List<Map<String, Any>> ?: emptyList()
+
+            val targets = targetsJson.map { targetJson ->
+                // Parse target dependencies from the JSON
+                val dependencies = targetJson["target_dependencies"] as? List<String> ?: emptyList()
+
+                TargetInfo(
+                    name = targetJson["name"] as String,
+                    path = targetJson["path"] as? String,
+                    targetDependencies = dependencies
+                )
+            }
+
+            return SwiftPackageInfo(targets)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/GenerateDefFileTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/GenerateDefFileTask.kt
@@ -1,0 +1,102 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift.task
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.security.MessageDigest
+
+/**
+ * Gradle task that generates a cinterop .def file for a Swift package.
+ *
+ * The .def file tells Kotlin/Native cinterop how to process the Swift-generated
+ * Objective-C header and link against the static library.
+ */
+abstract class GenerateDefFileTask : DefaultTask() {
+
+    /** The Kotlin package name for the generated bindings */
+    @get:Input
+    abstract val packageName: Property<String>
+
+    /** The module name (used in the `modules` directive) */
+    @get:Input
+    abstract val moduleName: Property<String>
+
+    /** The static library name (e.g., "libRevenueCat.a") */
+    @get:Input
+    abstract val libraryName: Property<String>
+
+    /** Optional custom declarations to force cinterop binding generation */
+    @get:Input
+    @get:Optional
+    abstract val customDeclarations: Property<String>
+
+    /** The Xcode toolchain path */
+    @get:Input
+    abstract val toolchainPath: Property<String>
+
+    /** The Swift source directory - used to compute a hash for cache invalidation */
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val swiftSourceDir: DirectoryProperty
+
+    /** The output .def file */
+    @get:OutputFile
+    abstract val defFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val file = defFile.get().asFile
+        file.parentFile.mkdirs()
+
+        val toolchain = toolchainPath.get()
+        // We add a hash of the Swift source directory to force cinterop to re-run when
+        // Swift source changes, even if the changes are non-public. This is necessary
+        // because we found using inputs.file() on the cinterop task directly causes
+        // failures when building debug after release (e.g. publishToMavenLocal). This
+        // seems related to the cinterop commonizer.
+        val sourceHash = computeSourceHash()
+
+        val baseContent = """
+            # sourceHash=$sourceHash
+            language = Objective-C
+            package = ${packageName.get()}
+            modules = ${moduleName.get()}
+            staticLibraries = ${libraryName.get()}
+            linkerOpts = -L/usr/lib/swift
+            linkerOpts.ios_x64 = -L$toolchain/lib/swift/iphonesimulator/
+            linkerOpts.ios_arm64 = -L$toolchain/lib/swift/iphoneos/
+            linkerOpts.ios_simulator_arm64 = -L$toolchain/lib/swift/iphonesimulator/
+        """.trimIndent()
+
+        val content = if (customDeclarations.isPresent) {
+            "$baseContent\n---\n\n${customDeclarations.get()}"
+        } else {
+            baseContent
+        }
+
+        file.writeText(content)
+    }
+
+    private fun computeSourceHash(): String {
+        val sourceDir = swiftSourceDir.get().asFile
+        val digest = MessageDigest.getInstance("MD5")
+
+        sourceDir.walkTopDown()
+            .filter { it.isFile && it.extension == "swift" }
+            .sortedBy { it.relativeTo(sourceDir).path }
+            .forEach { file ->
+                digest.update(file.relativeTo(sourceDir).path.toByteArray())
+                digest.update(file.readBytes())
+            }
+
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/SwiftBuildTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/SwiftBuildTask.kt
@@ -1,0 +1,143 @@
+package com.revenuecat.purchases.kmp.buildlogic.swift.task
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+
+/**
+ * Gradle task that compiles a Swift package target and produces:
+ * - A static library (.a file)
+ * - An Objective-C header (-Swift.h)
+ * - A module.modulemap for cinterop
+ */
+abstract class SwiftBuildTask @Inject constructor(
+    private val execOperations: ExecOperations
+) : DefaultTask() {
+
+    /** The Swift target to build (e.g. "RevenueCat") */
+    @get:Input
+    abstract val swiftTarget: Property<String>
+
+    /** The Swift SDK to use (e.g. "iphonesimulator", "iphoneos") */
+    @get:Input
+    abstract val sdk: Property<String>
+
+    /** The Swift triple to use (e.g. "arm64-apple-ios-simulator") */
+    @get:Input
+    abstract val triple: Property<String>
+
+    /** The name of the generated header file (e.g. "RevenueCat-Swift.h") */
+    @get:Input
+    abstract val headerName: Property<String>
+
+    /** The name of the static library (e.g. "libRevenueCat.a") */
+    @get:Input
+    abstract val libraryName: Property<String>
+
+    /** The module name for the modulemap (e.g. "RevenueCat") */
+    @get:Input
+    abstract val moduleName: Property<String>
+
+    /** The Swift build configuration ("debug" or "release") */
+    @get:Input
+    abstract val configuration: Property<String>
+
+    /** The Swift package directory */
+    @get:Internal
+    abstract val packageDir: DirectoryProperty
+
+    /** The Swift target's source directory (for tracking incremental builds) */
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val targetSourceDir: DirectoryProperty
+
+    /** The output directory for built artifacts */
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    /** The scratch directory for Swift */
+    @get:Internal
+    abstract val scratchDir: DirectoryProperty
+
+    @TaskAction
+    fun build() {
+        val targetOutputDir = outputDir.get().asFile
+        targetOutputDir.mkdirs()
+
+        val scratchPath = scratchDir.get().asFile
+        val sdkPath = getSdkPath(sdk.get())
+        val tripleValue = triple.get()
+        val targetName = swiftTarget.get()
+        val configValue = configuration.get()
+
+        execOperations.exec {
+            workingDir = packageDir.get().asFile
+            // Avoids trying to use the iOS SDK to parse the Package.swift when building from Xcode.
+            // Swift compilation still uses the correct SDK because of the -Xswiftc -sdk arguments.
+            // This environment change is only scoped to this subprocess.
+            environment("SDKROOT", "")
+            commandLine(
+                "xcrun", "swift", "build",
+                "--target", targetName,
+                "--configuration", configValue,
+                "--triple", tripleValue,
+                "--scratch-path", scratchPath.absolutePath,
+                "-Xswiftc", "-sdk",
+                "-Xswiftc", sdkPath,
+                "-Xcc", "-isysroot",
+                "-Xcc", sdkPath,
+                "-Xswiftc", "-emit-objc-header",
+                "-Xswiftc", "-emit-objc-header-path",
+                "-Xswiftc", targetOutputDir.resolve(headerName.get()).absolutePath
+            )
+        }
+
+        // Collect all .o files and create a static library with libtool
+        val buildPath = scratchPath.resolve("$tripleValue/$configValue")
+        val objectFiles = buildPath.resolve("$targetName.build")
+            .walkTopDown()
+            .filter { it.extension == "o" }
+            .toList()
+
+        if (objectFiles.isEmpty()) {
+            error("No object files found in ${buildPath.resolve("$targetName.build")}")
+        }
+
+        execOperations.exec {
+            commandLine(
+                listOf(
+                    "libtool", "-static", "-o",
+                    targetOutputDir.resolve(libraryName.get()).absolutePath
+                ) + objectFiles.map { it.absolutePath }
+            )
+        }
+
+        // Create module.modulemap to wrap the Swift header as a Clang module
+        val modulemapContent = """
+            module ${moduleName.get()} {
+                header "${headerName.get()}"
+                export *
+            }
+        """.trimIndent()
+        targetOutputDir.resolve("module.modulemap").writeText(modulemapContent)
+    }
+
+    private fun getSdkPath(sdk: String): String {
+        val output = ByteArrayOutputStream()
+        execOperations.exec {
+            commandLine("xcrun", "--sdk", sdk, "--show-sdk-path")
+            standardOutput = output
+        }
+        return output.toString().trim()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ org.gradle.configuration-cache=true
 
 #Kotlin
 kotlin.code.style=official
+kotlin.mpp.enableCInteropCommonization=true
 
 #Android
 android.useAndroidX=true


### PR DESCRIPTION
## Description

This adds functionality to our Gradle plugin that allows us to depend on a Swift package like so:

```kotlin
kotlin {
    sourceSets {
        iosMain.dependencies {
            swiftPackage(
                path = rootProject.file("upstream/purchases-ios"),
                target = "RevenueCat",
                packageName = "swiftPMImport.com.revenuecat.purchases.kn.core",
            )
        }
    }
}
```

This is not yet used anywhere. This PR just adds the capability. 

## Motivation
I'm working on improving the integration experience of purchases-kmp, by avoiding the need for app developers to add the purchases-hybrid-common dependency manually as this adds friction and prevents properly testing Kotlin/Native modules that depend on purchases-kmp. Instead, we will be embedding purchases-ios directly in purchases-kmp, handling all complexity for the app developers. This PR introduces all the build logic required for that.

## How it works
Most orchestration happens in `ConfigureSwiftDependencies`:
1. All calls to `swiftPackage()` are collected.
2. Each Swift source directory is resolved.
3. A `GenerateDefFileTask` is registered for each target, to generate [a def file](https://kotlinlang.org/docs/native-definition-file.html) for Kotlin/Native interop.
4. A `SwiftBuildTask` is registered for each target, which will compile the Swift code.
5. A cinterop configuration is created for each Kotlin target that depends on any Swift target. This will generate Kotlin bindings for the Objective-C headers in our Swift target.
6. The cinterop task is set to depend on the `GenerateDefFileTask` and `SwiftBuildTask`, to ensure the correct order of execution.
