### PR TITLE
Adjusts the package name of generated Kotlin bindings

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
         pod("PurchasesHybridCommon") {
             version = libs.versions.revenuecat.common.get()
             extraOpts += listOf("-compiler-option", "-fmodules")
+            packageName = "swiftPMImport.com.revenuecat.purchases.kn.core"
         }
     }
 }

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/AdTracker.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/AdTracker.ios.kt
@@ -1,12 +1,12 @@
 package com.revenuecat.purchases.kmp
 
-import cocoapods.PurchasesHybridCommon.IOSAPIAvailabilityChecker
-import cocoapods.PurchasesHybridCommon.RCCommonFunctionality
-import cocoapods.PurchasesHybridCommon.trackAdDisplayed
-import cocoapods.PurchasesHybridCommon.trackAdFailedToLoad
-import cocoapods.PurchasesHybridCommon.trackAdLoaded
-import cocoapods.PurchasesHybridCommon.trackAdOpened
-import cocoapods.PurchasesHybridCommon.trackAdRevenue
+import swiftPMImport.com.revenuecat.purchases.kn.core.IOSAPIAvailabilityChecker
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCommonFunctionality
+import swiftPMImport.com.revenuecat.purchases.kn.core.trackAdDisplayed
+import swiftPMImport.com.revenuecat.purchases.kn.core.trackAdFailedToLoad
+import swiftPMImport.com.revenuecat.purchases.kn.core.trackAdLoaded
+import swiftPMImport.com.revenuecat.purchases.kn.core.trackAdOpened
+import swiftPMImport.com.revenuecat.purchases.kn.core.trackAdRevenue
 import com.revenuecat.purchases.kmp.models.AdDisplayedData
 import com.revenuecat.purchases.kmp.models.AdFailedToLoadData
 import com.revenuecat.purchases.kmp.models.AdLoadedData

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/LogHandler.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/LogHandler.ios.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.kmp
 
-import cocoapods.PurchasesHybridCommon.RCLogLevel
-import cocoapods.PurchasesHybridCommon.RCLogLevelDebug
-import cocoapods.PurchasesHybridCommon.RCLogLevelError
-import cocoapods.PurchasesHybridCommon.RCLogLevelInfo
-import cocoapods.PurchasesHybridCommon.RCLogLevelVerbose
-import cocoapods.PurchasesHybridCommon.RCLogLevelWarn
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevel
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelDebug
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelError
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelVerbose
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelWarn
 
 private typealias IosLogHandler = (RCLogLevel, String?) -> Unit
 

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/LogLevel.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/LogLevel.ios.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.kmp
 
-import cocoapods.PurchasesHybridCommon.RCLogLevelDebug
-import cocoapods.PurchasesHybridCommon.RCLogLevelError
-import cocoapods.PurchasesHybridCommon.RCLogLevelInfo
-import cocoapods.PurchasesHybridCommon.RCLogLevelVerbose
-import cocoapods.PurchasesHybridCommon.RCLogLevelWarn
-import cocoapods.PurchasesHybridCommon.RCLogLevel as IosLogLevel
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelDebug
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelError
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelVerbose
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevelWarn
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCLogLevel as IosLogLevel
 
 internal fun IosLogLevel.toLogLevel(): LogLevel =
     when (this) {

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -1,22 +1,22 @@
 package com.revenuecat.purchases.kmp
 
-import cocoapods.PurchasesHybridCommon.IOSAPIAvailabilityChecker
-import cocoapods.PurchasesHybridCommon.RCCommonFunctionality
-import cocoapods.PurchasesHybridCommon.RCCustomerInfo
-import cocoapods.PurchasesHybridCommon.RCIntroEligibility
-import cocoapods.PurchasesHybridCommon.RCPurchaseParamsBuilder
-import cocoapods.PurchasesHybridCommon.RCPurchasesDelegateProtocol
-import cocoapods.PurchasesHybridCommon.RCStoreProduct
-import cocoapods.PurchasesHybridCommon.RCStoreTransaction
-import cocoapods.PurchasesHybridCommon.RCVirtualCurrencies
-import cocoapods.PurchasesHybridCommon.configureWithAPIKey
-import cocoapods.PurchasesHybridCommon.isWebPurchaseRedemptionURL
-import cocoapods.PurchasesHybridCommon.parseAsWebPurchaseRedemptionWithUrlString
-import cocoapods.PurchasesHybridCommon.recordPurchaseForProductID
-import cocoapods.PurchasesHybridCommon.setAirbridgeDeviceID
-import cocoapods.PurchasesHybridCommon.setAirshipChannelID
-import cocoapods.PurchasesHybridCommon.setOnesignalUserID
-import cocoapods.PurchasesHybridCommon.showStoreMessagesForTypes
+import swiftPMImport.com.revenuecat.purchases.kn.core.IOSAPIAvailabilityChecker
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCommonFunctionality
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCustomerInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibility
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchaseParamsBuilder
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchasesDelegateProtocol
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProduct
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreTransaction
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVirtualCurrencies
+import swiftPMImport.com.revenuecat.purchases.kn.core.configureWithAPIKey
+import swiftPMImport.com.revenuecat.purchases.kn.core.isWebPurchaseRedemptionURL
+import swiftPMImport.com.revenuecat.purchases.kn.core.parseAsWebPurchaseRedemptionWithUrlString
+import swiftPMImport.com.revenuecat.purchases.kn.core.recordPurchaseForProductID
+import swiftPMImport.com.revenuecat.purchases.kn.core.setAirbridgeDeviceID
+import swiftPMImport.com.revenuecat.purchases.kn.core.setAirshipChannelID
+import swiftPMImport.com.revenuecat.purchases.kn.core.setOnesignalUserID
+import swiftPMImport.com.revenuecat.purchases.kn.core.showStoreMessagesForTypes
 import com.revenuecat.purchases.kmp.ktx.mapEntriesNotNull
 import com.revenuecat.purchases.kmp.mappings.buildStoreTransaction
 import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
@@ -67,9 +67,9 @@ import com.revenuecat.purchases.kmp.models.WinBackOffer
 import com.revenuecat.purchases.kmp.strings.ConfigureStrings
 import platform.Foundation.NSError
 import platform.Foundation.NSURL
-import cocoapods.PurchasesHybridCommon.RCDangerousSettings as IosDangerousSettings
-import cocoapods.PurchasesHybridCommon.RCPurchases as IosPurchases
-import cocoapods.PurchasesHybridCommon.RCWinBackOffer as NativeIosWinBackOffer
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCDangerousSettings as IosDangerousSettings
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchases as IosPurchases
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCWinBackOffer as NativeIosWinBackOffer
 
 public actual class Purchases private constructor(private val iosPurchases: IosPurchases) {
     public actual companion object {

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/PurchasesDelegate.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/PurchasesDelegate.ios.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.kmp
 
-import cocoapods.PurchasesHybridCommon.RCCustomerInfo
-import cocoapods.PurchasesHybridCommon.RCPurchases
-import cocoapods.PurchasesHybridCommon.RCPurchasesDelegateProtocol
-import cocoapods.PurchasesHybridCommon.RCStoreProduct
-import cocoapods.PurchasesHybridCommon.RCStoreTransaction
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCustomerInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchases
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchasesDelegateProtocol
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProduct
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreTransaction
 import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
 import com.revenuecat.purchases.kmp.mappings.toPurchasesErrorOrThrow
 import com.revenuecat.purchases.kmp.mappings.toStoreProduct

--- a/mappings/build.gradle.kts
+++ b/mappings/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
         pod("PurchasesHybridCommon") {
             version = libs.versions.revenuecat.common.get()
             extraOpts += listOf("-compiler-option", "-fmodules")
+            packageName = "swiftPMImport.com.revenuecat.purchases.kn.core"
         }
     }
 }

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/CacheFetchPolicy.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/CacheFetchPolicy.ios.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCCacheFetchPolicyCachedOrFetched
-import cocoapods.PurchasesHybridCommon.RCCacheFetchPolicyFetchCurrent
-import cocoapods.PurchasesHybridCommon.RCCacheFetchPolicyFromCacheOnly
-import cocoapods.PurchasesHybridCommon.RCCacheFetchPolicyNotStaleCachedOrFetched
 import com.revenuecat.purchases.kmp.models.CacheFetchPolicy
-import cocoapods.PurchasesHybridCommon.RCCacheFetchPolicy as IosCacheFetchPolicy
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCacheFetchPolicyCachedOrFetched
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCacheFetchPolicyFetchCurrent
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCacheFetchPolicyFromCacheOnly
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCacheFetchPolicyNotStaleCachedOrFetched
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCacheFetchPolicy as IosCacheFetchPolicy
 
 public fun CacheFetchPolicy.toIosCacheFetchPolicy(): IosCacheFetchPolicy =
     when (this) {

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/CustomerInfo.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/CustomerInfo.ios.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.kmp.mappings.ktx.toEpochMilliseconds
 import com.revenuecat.purchases.kmp.models.CustomerInfo
 import platform.Foundation.dictionaryWithValuesForKeys
 import platform.darwin.NSObject
-import cocoapods.PurchasesHybridCommon.RCCustomerInfo as IosCustomerInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCustomerInfo as IosCustomerInfo
 
 public fun IosCustomerInfo.toCustomerInfo(): CustomerInfo {
     @Suppress("UNCHECKED_CAST")

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/DiscountPaymentMode.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/DiscountPaymentMode.ios.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCPaymentModeFreeTrial
-import cocoapods.PurchasesHybridCommon.RCPaymentModePayAsYouGo
-import cocoapods.PurchasesHybridCommon.RCPaymentModePayUpFront
 import com.revenuecat.purchases.kmp.models.DiscountPaymentMode
-import cocoapods.PurchasesHybridCommon.RCPaymentMode as IosDiscountPaymentMode
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPaymentModeFreeTrial
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPaymentModePayAsYouGo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPaymentModePayUpFront
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPaymentMode as IosDiscountPaymentMode
 
 internal fun IosDiscountPaymentMode.toDiscountPaymentMode(): DiscountPaymentMode =
     when (this) {

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/DiscountType.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/DiscountType.ios.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCDiscountTypeIntroductory
-import cocoapods.PurchasesHybridCommon.RCDiscountTypePromotional
-import cocoapods.PurchasesHybridCommon.RCDiscountTypeWinBack
 import com.revenuecat.purchases.kmp.models.DiscountType
-import cocoapods.PurchasesHybridCommon.RCDiscountType as IosDiscountType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCDiscountTypeIntroductory
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCDiscountTypePromotional
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCDiscountTypeWinBack
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCDiscountType as IosDiscountType
 
 internal fun IosDiscountType.toDiscountType(): DiscountType =
     when(this) {

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/EntitlementInfo.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/EntitlementInfo.ios.kt
@@ -1,31 +1,31 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCAmazon
-import cocoapods.PurchasesHybridCommon.RCAppStore
-import cocoapods.PurchasesHybridCommon.RCBilling
-import cocoapods.PurchasesHybridCommon.RCEntitlementInfo
-import cocoapods.PurchasesHybridCommon.RCIntro
-import cocoapods.PurchasesHybridCommon.RCMacAppStore
-import cocoapods.PurchasesHybridCommon.RCNormal
-import cocoapods.PurchasesHybridCommon.RCPaddle
-import cocoapods.PurchasesHybridCommon.RCPrepaid
-import cocoapods.PurchasesHybridCommon.RCPlayStore
-import cocoapods.PurchasesHybridCommon.RCPromotional
-import cocoapods.PurchasesHybridCommon.RCPurchaseOwnershipTypeFamilyShared
-import cocoapods.PurchasesHybridCommon.RCPurchaseOwnershipTypePurchased
-import cocoapods.PurchasesHybridCommon.RCPurchaseOwnershipTypeUnknown
-import cocoapods.PurchasesHybridCommon.RCStripe
-import cocoapods.PurchasesHybridCommon.RCTestStore
-import cocoapods.PurchasesHybridCommon.RCTrial
-import cocoapods.PurchasesHybridCommon.RCUnknownStore
 import com.revenuecat.purchases.kmp.mappings.ktx.toEpochMilliseconds
 import com.revenuecat.purchases.kmp.models.EntitlementInfo
 import com.revenuecat.purchases.kmp.models.OwnershipType
 import com.revenuecat.purchases.kmp.models.PeriodType
 import com.revenuecat.purchases.kmp.models.Store
-import cocoapods.PurchasesHybridCommon.RCPeriodType as IosPeriodType
-import cocoapods.PurchasesHybridCommon.RCPurchaseOwnershipType as IosOwnershipType
-import cocoapods.PurchasesHybridCommon.RCStore as IosStore
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCAmazon
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCAppStore
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCBilling
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCEntitlementInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntro
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCMacAppStore
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCNormal
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPaddle
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPlayStore
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPrepaid
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPromotional
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchaseOwnershipTypeFamilyShared
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchaseOwnershipTypePurchased
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchaseOwnershipTypeUnknown
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStripe
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCTestStore
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCTrial
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCUnknownStore
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPeriodType as IosPeriodType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchaseOwnershipType as IosOwnershipType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStore as IosStore
 
 internal fun RCEntitlementInfo.toEntitlementInfo(): EntitlementInfo {
     return EntitlementInfo(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/EntitlementInfos.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/EntitlementInfos.ios.kt
@@ -1,9 +1,9 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCEntitlementInfo
-import cocoapods.PurchasesHybridCommon.RCEntitlementInfos
 import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
 import com.revenuecat.purchases.kmp.models.EntitlementInfos
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCEntitlementInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCEntitlementInfos
 
 internal fun RCEntitlementInfos.toEntitlementInfos(): EntitlementInfos =
     EntitlementInfos(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/IntroEligibilityStatus.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/IntroEligibilityStatus.ios.kt
@@ -1,12 +1,12 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCIntroEligibility
-import cocoapods.PurchasesHybridCommon.RCIntroEligibilityStatus
-import cocoapods.PurchasesHybridCommon.RCIntroEligibilityStatusEligible
-import cocoapods.PurchasesHybridCommon.RCIntroEligibilityStatusIneligible
-import cocoapods.PurchasesHybridCommon.RCIntroEligibilityStatusNoIntroOfferExists
-import cocoapods.PurchasesHybridCommon.RCIntroEligibilityStatusUnknown
 import com.revenuecat.purchases.kmp.models.IntroEligibilityStatus
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibility
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibilityStatus
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibilityStatusEligible
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibilityStatusIneligible
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibilityStatusNoIntroOfferExists
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCIntroEligibilityStatusUnknown
 
 public fun RCIntroEligibility.toIntroEligibilityStatus(): IntroEligibilityStatus =
     status().toIntroEligibilityStatus()

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offering.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offering.ios.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.kmp.mappings
 
+import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
 import com.revenuecat.purchases.kmp.models.Offering
 import com.revenuecat.purchases.kmp.models.Package
-import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
-import cocoapods.PurchasesHybridCommon.RCOffering as NativeIosOffering
-import cocoapods.PurchasesHybridCommon.RCPackage as NativeIosPackage
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCOffering as NativeIosOffering
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackage as NativeIosPackage
 
 public fun NativeIosOffering.toOffering(): Offering =
     IosOffering(this)

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Offerings.ios.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.currentOfferingForPlacement
 import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
 import com.revenuecat.purchases.kmp.models.Offerings
-import cocoapods.PurchasesHybridCommon.RCOffering as IosOffering
-import cocoapods.PurchasesHybridCommon.RCOfferings as IosOfferings
+import swiftPMImport.com.revenuecat.purchases.kn.core.currentOfferingForPlacement
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCOffering as IosOffering
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCOfferings as IosOfferings
 
 public fun IosOfferings.toOfferings(): Offerings =
     Offerings(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Package.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Package.ios.kt
@@ -3,18 +3,18 @@ package com.revenuecat.purchases.kmp.mappings
 import com.revenuecat.purchases.kmp.models.PackageType
 import com.revenuecat.purchases.kmp.models.PresentedOfferingContext
 import com.revenuecat.purchases.kmp.models.StoreProduct
-import cocoapods.PurchasesHybridCommon.RCPackage as NativeIosPackage
-import cocoapods.PurchasesHybridCommon.RCPackageType as IosPackageType
-import cocoapods.PurchasesHybridCommon.RCPackageTypeAnnual as IosPackageTypeAnnual
-import cocoapods.PurchasesHybridCommon.RCPackageTypeCustom as IosPackageTypeCustom
-import cocoapods.PurchasesHybridCommon.RCPackageTypeLifetime as IosPackageTypeLifetime
-import cocoapods.PurchasesHybridCommon.RCPackageTypeMonthly as IosPackageTypeMonthly
-import cocoapods.PurchasesHybridCommon.RCPackageTypeSixMonth as IosPackageTypeSixMonth
-import cocoapods.PurchasesHybridCommon.RCPackageTypeThreeMonth as IosPackageTypeThreeMonth
-import cocoapods.PurchasesHybridCommon.RCPackageTypeTwoMonth as IosPackageTypeTwoMonth
-import cocoapods.PurchasesHybridCommon.RCPackageTypeUnknown as IosPackageTypeUnknown
-import cocoapods.PurchasesHybridCommon.RCPackageTypeWeekly as IosPackageTypeWeekly
 import com.revenuecat.purchases.kmp.models.Package as RCPackage
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackage as NativeIosPackage
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageType as IosPackageType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeAnnual as IosPackageTypeAnnual
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeCustom as IosPackageTypeCustom
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeLifetime as IosPackageTypeLifetime
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeMonthly as IosPackageTypeMonthly
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeSixMonth as IosPackageTypeSixMonth
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeThreeMonth as IosPackageTypeThreeMonth
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeTwoMonth as IosPackageTypeTwoMonth
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeUnknown as IosPackageTypeUnknown
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackageTypeWeekly as IosPackageTypeWeekly
 
 public fun NativeIosPackage.toPackage(): RCPackage = IosPackage(this)
 

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Period.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Period.ios.kt
@@ -1,13 +1,13 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCSubscriptionPeriod as IosPeriod
-import cocoapods.PurchasesHybridCommon.RCSubscriptionPeriodUnit as IosPeriodUnit
-import cocoapods.PurchasesHybridCommon.RCSubscriptionPeriodUnitDay
-import cocoapods.PurchasesHybridCommon.RCSubscriptionPeriodUnitMonth
-import cocoapods.PurchasesHybridCommon.RCSubscriptionPeriodUnitWeek
-import cocoapods.PurchasesHybridCommon.RCSubscriptionPeriodUnitYear
 import com.revenuecat.purchases.kmp.models.Period
 import com.revenuecat.purchases.kmp.models.PeriodUnit
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCSubscriptionPeriodUnitDay
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCSubscriptionPeriodUnitMonth
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCSubscriptionPeriodUnitWeek
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCSubscriptionPeriodUnitYear
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCSubscriptionPeriod as IosPeriod
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCSubscriptionPeriodUnit as IosPeriodUnit
 
 internal fun IosPeriod.toPeriod(): Period = Period(value().toInt(), unit().toPeriodUnit())
 

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PresentedOfferingContext.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PresentedOfferingContext.ios.kt
@@ -2,8 +2,8 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.PresentedOfferingContext
 import com.revenuecat.purchases.kmp.models.PresentedOfferingTargetingContext
-import cocoapods.PurchasesHybridCommon.RCPresentedOfferingContext as IosPresentedOfferingContext
-import cocoapods.PurchasesHybridCommon.RCTargetingContext as IosPresentedOfferingTargetingContext
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPresentedOfferingContext as IosPresentedOfferingContext
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCTargetingContext as IosPresentedOfferingTargetingContext
 
 internal fun IosPresentedOfferingContext.toPresentedOfferingContext() = PresentedOfferingContext(
     offeringIdentifier = offeringIdentifier(),

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.ios.kt
@@ -1,10 +1,10 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCStoreProduct
-import cocoapods.PurchasesHybridCommon.RCStoreProductDiscount
-import cocoapods.PurchasesHybridCommon.priceAmount
 import com.revenuecat.purchases.kmp.models.Price
 import platform.Foundation.NSDecimalNumber
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProduct
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductDiscount
+import swiftPMImport.com.revenuecat.purchases.kn.core.priceAmount
 
 internal fun RCStoreProduct.toPrice(): Price =
     Price(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/ProductCategory.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/ProductCategory.ios.kt
@@ -1,9 +1,9 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCStoreProductCategory
-import cocoapods.PurchasesHybridCommon.RCStoreProductCategoryNonSubscription
-import cocoapods.PurchasesHybridCommon.RCStoreProductCategorySubscription
 import com.revenuecat.purchases.kmp.models.ProductCategory
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductCategory
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductCategoryNonSubscription
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductCategorySubscription
 
 internal fun RCStoreProductCategory.toProductCategory(): ProductCategory =
     when (this) {

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/ProductType.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/ProductType.ios.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCStoreProductTypeAutoRenewableSubscription
-import cocoapods.PurchasesHybridCommon.RCStoreProductTypeConsumable
-import cocoapods.PurchasesHybridCommon.RCStoreProductTypeNonConsumable
-import cocoapods.PurchasesHybridCommon.RCStoreProductTypeNonRenewableSubscription
 import com.revenuecat.purchases.kmp.models.ProductType
-import cocoapods.PurchasesHybridCommon.RCStoreProductType as IosStoreProductType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductTypeAutoRenewableSubscription
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductTypeConsumable
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductTypeNonConsumable
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductTypeNonRenewableSubscription
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductType as IosStoreProductType
 
 internal fun IosStoreProductType.toProductType(): ProductType =
     when (this) {

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PromotionalOffer.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PromotionalOffer.ios.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.PromotionalOffer
 import com.revenuecat.purchases.kmp.models.StoreProductDiscount
-import cocoapods.PurchasesHybridCommon.RCPromotionalOffer as NativeIosPromotionalOffer
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPromotionalOffer as NativeIosPromotionalOffer
 
 public fun NativeIosPromotionalOffer.toPromotionalOffer(): PromotionalOffer =
     IosPromotionalOffer(this)

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PurchasingData.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/PurchasingData.ios.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.ProductType
 import com.revenuecat.purchases.kmp.models.PurchasingData
-import cocoapods.PurchasesHybridCommon.RCStoreProduct as NativeIosStoreProduct
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProduct as NativeIosStoreProduct
 
 internal class IosPurchasingData(
     product: NativeIosStoreProduct

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProduct.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProduct.ios.kt
@@ -1,13 +1,7 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.pricePerMonthAmount
-import cocoapods.PurchasesHybridCommon.pricePerMonthString
-import cocoapods.PurchasesHybridCommon.pricePerWeekAmount
-import cocoapods.PurchasesHybridCommon.pricePerWeekString
-import cocoapods.PurchasesHybridCommon.pricePerYearAmount
-import cocoapods.PurchasesHybridCommon.pricePerYearString
-import com.revenuecat.purchases.kmp.models.PresentedOfferingContext
 import com.revenuecat.purchases.kmp.models.Period
+import com.revenuecat.purchases.kmp.models.PresentedOfferingContext
 import com.revenuecat.purchases.kmp.models.Price
 import com.revenuecat.purchases.kmp.models.ProductCategory
 import com.revenuecat.purchases.kmp.models.ProductType
@@ -16,8 +10,14 @@ import com.revenuecat.purchases.kmp.models.StoreProduct
 import com.revenuecat.purchases.kmp.models.StoreProductDiscount
 import com.revenuecat.purchases.kmp.models.SubscriptionOption
 import com.revenuecat.purchases.kmp.models.SubscriptionOptions
-import cocoapods.PurchasesHybridCommon.RCStoreProduct as NativeIosStoreProduct
-import cocoapods.PurchasesHybridCommon.RCStoreProductDiscount as IosStoreProductDiscount
+import swiftPMImport.com.revenuecat.purchases.kn.core.pricePerMonthAmount
+import swiftPMImport.com.revenuecat.purchases.kn.core.pricePerMonthString
+import swiftPMImport.com.revenuecat.purchases.kn.core.pricePerWeekAmount
+import swiftPMImport.com.revenuecat.purchases.kn.core.pricePerWeekString
+import swiftPMImport.com.revenuecat.purchases.kn.core.pricePerYearAmount
+import swiftPMImport.com.revenuecat.purchases.kn.core.pricePerYearString
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProduct as NativeIosStoreProduct
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductDiscount as IosStoreProductDiscount
 
 public fun NativeIosStoreProduct.toStoreProduct(): StoreProduct =
     IosStoreProduct(this)

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProductDiscount.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProductDiscount.ios.kt
@@ -5,7 +5,7 @@ import com.revenuecat.purchases.kmp.models.DiscountType
 import com.revenuecat.purchases.kmp.models.Period
 import com.revenuecat.purchases.kmp.models.Price
 import com.revenuecat.purchases.kmp.models.StoreProductDiscount
-import cocoapods.PurchasesHybridCommon.RCStoreProductDiscount as NativeIosStoreProductDiscount
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreProductDiscount as NativeIosStoreProductDiscount
 
 public fun NativeIosStoreProductDiscount.toStoreProductDiscount(): StoreProductDiscount =
     IosStoreProductDiscount(this)

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreTransaction.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreTransaction.ios.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.mappings.ktx.toEpochMilliseconds
 import com.revenuecat.purchases.kmp.models.StoreTransaction
-import cocoapods.PurchasesHybridCommon.RCStoreTransaction as IosStoreTransaction
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreTransaction as IosStoreTransaction
 
 public fun IosStoreTransaction.toStoreTransaction(): StoreTransaction =
     StoreTransaction(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Storefront.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/Storefront.ios.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCStorefront
 import com.revenuecat.purchases.kmp.models.Storefront
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStorefront
 
 public fun RCStorefront.toStorefront(): Storefront =
     Storefront(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/SubscriptionInfo.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/SubscriptionInfo.ios.kt
@@ -1,8 +1,5 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCPeriodType
-import cocoapods.PurchasesHybridCommon.RCPurchaseOwnershipType
-import cocoapods.PurchasesHybridCommon.RCStore
 import com.revenuecat.purchases.kmp.mappings.ktx.toEpochMilliseconds
 import com.revenuecat.purchases.kmp.models.Price
 import com.revenuecat.purchases.kmp.models.SubscriptionInfo
@@ -10,6 +7,9 @@ import platform.Foundation.NSDate
 import platform.Foundation.NSURL
 import platform.Foundation.valueForKey
 import platform.darwin.NSObject
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPeriodType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchaseOwnershipType
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStore
 
 internal fun Any.toSubscriptionInfo(): SubscriptionInfo {
     val obj = this as NSObject

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/VerificationResult.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/VerificationResult.ios.kt
@@ -1,11 +1,11 @@
 package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.VerificationResult
-import cocoapods.PurchasesHybridCommon.RCVerificationResult as IosVerificationResult
-import cocoapods.PurchasesHybridCommon.RCVerificationResultFailed as IosVerificationResultFailed
-import cocoapods.PurchasesHybridCommon.RCVerificationResultNotRequested as IosVerificationResultNotRequested
-import cocoapods.PurchasesHybridCommon.RCVerificationResultVerified as IosVerificationResultVerified
-import cocoapods.PurchasesHybridCommon.RCVerificationResultVerifiedOnDevice as IosVerificationResultVerifiedOnDevice
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVerificationResult as IosVerificationResult
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVerificationResultFailed as IosVerificationResultFailed
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVerificationResultNotRequested as IosVerificationResultNotRequested
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVerificationResultVerified as IosVerificationResultVerified
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVerificationResultVerifiedOnDevice as IosVerificationResultVerifiedOnDevice
 
 internal fun IosVerificationResult.toVerificationResult(): VerificationResult =
     when (this) {

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/VirtualCurrencies.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/VirtualCurrencies.ios.kt
@@ -1,9 +1,9 @@
 package com.revenuecat.purchases.kmp.mappings
 
-import cocoapods.PurchasesHybridCommon.RCVirtualCurrency
 import com.revenuecat.purchases.kmp.mappings.ktx.mapEntries
 import com.revenuecat.purchases.kmp.models.VirtualCurrencies
-import cocoapods.PurchasesHybridCommon.RCVirtualCurrencies as IosVirtualCurrencies
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVirtualCurrency
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVirtualCurrencies as IosVirtualCurrencies
 
 public fun IosVirtualCurrencies.toVirtualCurrencies(): VirtualCurrencies {
     return VirtualCurrencies(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/VirtualCurrency.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/VirtualCurrency.ios.kt
@@ -1,7 +1,7 @@
 package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.VirtualCurrency
-import cocoapods.PurchasesHybridCommon.RCVirtualCurrency as IosVirtualCurrency
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCVirtualCurrency as IosVirtualCurrency
 
 public fun IosVirtualCurrency.toVirtualCurrency(): VirtualCurrency {
     return VirtualCurrency(

--- a/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/WinBackOffer.ios.kt
+++ b/mappings/src/iosMain/kotlin/com/revenuecat/purchases/kmp/mappings/WinBackOffer.ios.kt
@@ -2,7 +2,7 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.models.StoreProductDiscount
 import com.revenuecat.purchases.kmp.models.WinBackOffer
-import cocoapods.PurchasesHybridCommon.RCWinBackOffer as NativeIosWinBackOffer
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCWinBackOffer as NativeIosWinBackOffer
 
 public fun NativeIosWinBackOffer.toWinBackOffer(): WinBackOffer =
     IosWinBackOffer(this)

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         pod("PurchasesHybridCommon") {
             version = libs.versions.revenuecat.common.get()
             extraOpts += listOf("-compiler-option", "-fmodules")
+            packageName = "swiftPMImport.com.revenuecat.purchases.kn.core"
         }
     }
 }

--- a/revenuecatui/build.gradle.kts
+++ b/revenuecatui/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
         pod("PurchasesHybridCommonUI") {
             version = libs.versions.revenuecat.common.get()
             extraOpts += listOf("-compiler-option", "-fmodules")
+            packageName = "swiftPMImport.com.revenuecat.purchases.kn.ui"
         }
     }
 }

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -1,10 +1,5 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
-import cocoapods.PurchasesHybridCommonUI.RCCustomerInfo
-import cocoapods.PurchasesHybridCommonUI.RCPackage
-import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
-import cocoapods.PurchasesHybridCommonUI.RCPaywallViewControllerDelegateProtocol
-import cocoapods.PurchasesHybridCommonUI.RCStoreTransaction
 import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
 import com.revenuecat.purchases.kmp.mappings.toPackage
 import com.revenuecat.purchases.kmp.mappings.toPurchasesErrorOrThrow
@@ -16,9 +11,14 @@ import kotlinx.cinterop.pointed
 import platform.CoreGraphics.CGSize
 import platform.Foundation.NSError
 import platform.darwin.NSObject
-import cocoapods.PurchasesHybridCommon.RCCustomerInfo as PhcCustomerInfo
-import cocoapods.PurchasesHybridCommon.RCPackage as PhcPackage
-import cocoapods.PurchasesHybridCommon.RCStoreTransaction as PhcStoreTransaction
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCCustomerInfo
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCPackage
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCPaywallViewController
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCPaywallViewControllerDelegateProtocol
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCStoreTransaction
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCCustomerInfo as PhcCustomerInfo
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCPackage as PhcPackage
+import swiftPMImport.com.revenuecat.purchases.kn.core.RCStoreTransaction as PhcStoreTransaction
 
 internal class IosPaywallDelegate(
     private val listener: PaywallListener?,

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitCustomerCenter.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitCustomerCenter.kt
@@ -4,8 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitViewController
-import cocoapods.PurchasesHybridCommonUI.CustomerCenterUIViewController
-import cocoapods.PurchasesHybridCommonUI.RCCustomerCenterViewControllerDelegateWrapperProtocol
+import swiftPMImport.com.revenuecat.purchases.kn.ui.CustomerCenterUIViewController
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCCustomerCenterViewControllerDelegateWrapperProtocol
 import com.revenuecat.purchases.kmp.ui.revenuecatui.modifier.layoutViewController
 import com.revenuecat.purchases.kmp.ui.revenuecatui.modifier.rememberLayoutViewControllerState
 import platform.darwin.NSObject

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/UIKitPaywall.kt
@@ -4,12 +4,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.UIKitViewController
-import cocoapods.PurchasesHybridCommonUI.RCPaywallFooterViewController
-import cocoapods.PurchasesHybridCommonUI.RCPaywallViewController
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCPaywallFooterViewController
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCPaywallViewController
 import com.revenuecat.purchases.kmp.mappings.toIosOffering
 import com.revenuecat.purchases.kmp.ui.revenuecatui.modifier.layoutViewController
 import com.revenuecat.purchases.kmp.ui.revenuecatui.modifier.rememberLayoutViewControllerState
-import cocoapods.PurchasesHybridCommonUI.RCOffering
+import swiftPMImport.com.revenuecat.purchases.kn.ui.RCOffering
 
 @Composable
 internal fun UIKitPaywall(


### PR DESCRIPTION
## Motivation
I'm working on improving the integration experience of purchases-kmp, by avoiding the need for app developers to add the purchases-hybrid-common dependency manually as this adds friction and prevents properly testing Kotlin/Native modules that depend on purchases-kmp. Instead, we will be embedding purchases-ios directly in purchases-kmp, handling all complexity for the app developers. 

## Changes
This PR only changes the package name of the generated Kotlin bindings in preparation for SPM import. This helps keep the follow-up PRs smaller. No logic has changed in this PR. These are internal changes only. 