### PR TITLE
Bump fastlane-plugin-revenuecat_internal to ea6276c

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: afc92198e949d698da8ad968d73a10b67f183df1
+  revision: ea6276ccc9fa140d0fab6ca464cbb5e5fe59ce83
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
## Summary
- Bumps fastlane-plugin-revenuecat_internal from `afc9219` to `ea6276c`
- Adds `enable_auto_merge` support to `bump_phc_version` action

## Related
- https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/commit/ea6276ccc9fa140d0fab6ca464cbb5e5fe59ce83

🤖 Generated with [Claude Code](https://claude.com/claude-code)