### PR TITLE
feat: add convenience method for canMakePayments

### DIFF
--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
@@ -69,8 +69,6 @@ import com.revenuecat.purchases.restorePurchasesWith
 import com.revenuecat.purchases.syncAttributesAndOfferingsIfNeededWith
 import com.revenuecat.purchases.syncPurchasesWith
 import java.net.URL
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import com.revenuecat.purchases.DangerousSettings as AndroidDangerousSettings
 import com.revenuecat.purchases.Purchases as AndroidPurchases
 import com.revenuecat.purchases.hybridcommon.configure as commonConfigure

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -67,8 +67,6 @@ import com.revenuecat.purchases.kmp.models.WinBackOffer
 import com.revenuecat.purchases.kmp.strings.ConfigureStrings
 import platform.Foundation.NSError
 import platform.Foundation.NSURL
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 import swiftPMImport.com.revenuecat.purchases.kn.core.RCDangerousSettings as IosDangerousSettings
 import swiftPMImport.com.revenuecat.purchases.kn.core.RCPurchases as IosPurchases
 import swiftPMImport.com.revenuecat.purchases.kn.core.RCWinBackOffer as NativeIosWinBackOffer


### PR DESCRIPTION
### Checklist

- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other
  hybrids

### Motivation

In most cases, people prefer using suspending functions to callbacks (mostly for chaining calls), so i figured it would be good to add the method for it.

admittedly i do feel like there being two methods doing the same thing is a little bit of a smell especially for something this small, but removing the non suspending call is a breaking change, and the android SDK very much uses callbacks, and i would like to get some feedback if this is a route that would make sense to pursue or not, and if so, i can do a PR on Android too.
Resolves #689

### Description

Add a convenience suspending function for the `canMakePayments` method on the SDK called `awaitCanMakePayments`
Re-ran apiDump to make sure the list of APIs is up to date
No specific validations done, as there is not much to the API
