### PR TITLE
Add maestro E2E test for purchase through paywall

### DIFF
--- a/e2e-tests/maestro/config.yaml
+++ b/e2e-tests/maestro/config.yaml
@@ -1,0 +1,7 @@
+# config.yaml
+
+executionOrder:
+  continueOnFailure: false
+
+flows:
+  - e2e_tests/*

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -20,11 +20,13 @@ name: Purchase through paywall
 - extendedWaitUntil:
     visible: "Entitlements: none"
     timeout: 15000
+- takeScreenshot: purchase_through_paywall - Purchase screen
 - assertVisible: "Entitlements: none"
 - assertVisible: "Present Paywall"
 - tapOn:
     text: "Present Paywall"
 - assertVisible: "Paywall V2"
+- takeScreenshot: purchase_through_paywall - Paywall
 - tapOn:
     text: "Yearly"
 - tapOn:
@@ -34,4 +36,5 @@ name: Purchase through paywall
 - extendedWaitUntil:
     visible: "Entitlements: pro"
     timeout: 15000
+- takeScreenshot: purchase_through_paywall - Entitlements unlocked
 - assertVisible: "Entitlements: pro"

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -9,24 +9,20 @@ name: Purchase through paywall
 - clearState
 - pressKey: home
 - launchApp
-- takeScreenshot: purchase_through_paywall - Initial state after launch
 - extendedWaitUntil:
     visible: "Test Cases"
     timeout: 30000
-- takeScreenshot: purchase_through_paywall - After Test Cases visible
 - assertVisible: "Test Cases"
 - tapOn:
     text: "Purchase through paywall"
 - extendedWaitUntil:
     visible: "Entitlements: none"
     timeout: 15000
-- takeScreenshot: purchase_through_paywall - Purchase screen
 - assertVisible: "Entitlements: none"
 - assertVisible: "Present Paywall"
 - tapOn:
     text: "Present Paywall"
 - assertVisible: "Paywall V2"
-- takeScreenshot: purchase_through_paywall - Paywall
 - tapOn:
     text: "Yearly"
 - tapOn:
@@ -36,5 +32,4 @@ name: Purchase through paywall
 - extendedWaitUntil:
     visible: "Entitlements: pro"
     timeout: 15000
-- takeScreenshot: purchase_through_paywall - Entitlements unlocked
 - assertVisible: "Entitlements: pro"

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -24,7 +24,7 @@ name: Purchase through paywall
     text: "Present Paywall"
 - extendedWaitUntil:
     visible: "Paywall V2"
-    timeout: 30000
+    timeout: 15000
 - assertVisible: "Paywall V2"
 - tapOn:
     text: "Yearly"

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -22,6 +22,9 @@ name: Purchase through paywall
 - assertVisible: "Present Paywall"
 - tapOn:
     text: "Present Paywall"
+- extendedWaitUntil:
+    visible: "Paywall V2"
+    timeout: 15000
 - assertVisible: "Paywall V2"
 - tapOn:
     text: "Yearly"

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -24,7 +24,7 @@ name: Purchase through paywall
     text: "Present Paywall"
 - extendedWaitUntil:
     visible: "Paywall V2"
-    timeout: 15000
+    timeout: 30000
 - assertVisible: "Paywall V2"
 - tapOn:
     text: "Yearly"

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -1,0 +1,37 @@
+# This flow tests the purchase through paywall flow.
+# It navigates to the purchase screen, verifies initial entitlements,
+# presents the paywall, makes a purchase, and verifies entitlements update.
+
+appId: com.revenuecat.automatedsdktests
+name: Purchase through paywall
+
+---
+- clearState
+- pressKey: home
+- launchApp
+- takeScreenshot: purchase_through_paywall - Initial state after launch
+- extendedWaitUntil:
+    visible: "Test Cases"
+    timeout: 30000
+- takeScreenshot: purchase_through_paywall - After Test Cases visible
+- assertVisible: "Test Cases"
+- tapOn:
+    text: "Purchase through paywall"
+- extendedWaitUntil:
+    visible: "Entitlements: none"
+    timeout: 15000
+- assertVisible: "Entitlements: none"
+- assertVisible: "Present Paywall"
+- tapOn:
+    text: "Present Paywall"
+- assertVisible: "Paywall V2"
+- tapOn:
+    text: "Yearly"
+- tapOn:
+    text: "Continue"
+- runFlow:
+    file: ../utils/confirm_purchase.yaml
+- extendedWaitUntil:
+    visible: "Entitlements: pro"
+    timeout: 15000
+- assertVisible: "Entitlements: pro"

--- a/e2e-tests/maestro/utils/confirm_purchase.yaml
+++ b/e2e-tests/maestro/utils/confirm_purchase.yaml
@@ -1,0 +1,9 @@
+# This flow handles the Test Store purchase confirmation.
+
+appId: com.revenuecat.automatedsdktests
+name: Confirm purchase - Test Store Purchase Alert
+
+---
+- assertVisible: "Test.*Purchase"
+- tapOn:
+    text: "(?i)test valid purchase"


### PR DESCRIPTION
## Summary
- Adds Maestro YAML test files for the "purchase through paywall" E2E flow
- Adds `config.yaml` for Maestro test execution
- Test flow: clear state → launch app → navigate to purchase screen → verify no entitlements → present V2 paywall → select "Yearly" → tap "Continue" → confirm purchase → verify "pro" entitlement
- Adds `utils/confirm_purchase.yaml` utility that handles test store purchase confirmation on both iOS and Android (using regex to match platform-specific alert text)

Depends on #708