### PR TITLE
Add CircleCI job for maestro E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,6 +409,10 @@ jobs:
     macos:
       xcode: 16.4.0
     resource_class: m4pro.medium
+    parameters:
+      simulator-name:
+        type: string
+        default: "iPhone 16 Pro"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -428,11 +432,11 @@ jobs:
       - run:
           name: Boot iOS Simulator
           command: |
-            xcrun simctl boot "iPhone 16 Pro" || true
-            xcrun simctl bootstatus "iPhone 16 Pro" -b
+            xcrun simctl boot "<< parameters.simulator-name >>" || true
+            xcrun simctl bootstatus "<< parameters.simulator-name >>" -b
       - run:
           name: Run Maestro E2E Tests (iOS)
-          command: bundle exec fastlane run_maestro_e2e_tests_ios
+          command: bundle exec fastlane run_maestro_e2e_tests_ios simulator_name:"<< parameters.simulator-name >>"
           no_output_timeout: 15m
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
@@ -452,10 +456,12 @@ jobs:
           command: |
             gem install bundler
             bundle install
+      - restore-gradle-user-home-directory-from-cache
       - run:
           name: Build Maestro app (Android)
           command: bundle exec fastlane build_maestro_app_android
           no_output_timeout: 15m
+      - save-gradle-user-home-directory-to-cache
       - android/create-avd:
           avd-name: test-e2e
           system-image: system-images;android-34;google_apis;x86_64
@@ -486,7 +492,7 @@ jobs:
           command: bundle exec fastlane github_release_current_version
 
 workflows:
-  maestro-e2e-tests-ios:
+  maestro-e2e-tests:
     when:
       or:
         - and:
@@ -497,14 +503,6 @@ workflows:
           context:
             - maestro-e2e-tests
             - e2e-tests
-
-  maestro-e2e-tests-android:
-    when:
-      or:
-        - and:
-            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-            - equal: [ "maestro_e2e_tests", << pipeline.schedule.name >> ]
-    jobs:
       - run-maestro-e2e-tests-android:
           context:
             - maestro-e2e-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ commands:
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - android/accept-licenses
       - run:
-          name: Install Android SDK components
-          command: sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
+          name: Install Android SDK platform tools
+          command: sdkmanager "platform-tools"
 
   install-cocoapods-on-macos:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ commands:
             echo 'export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"' >> "$BASH_ENV"
       - android/accept-licenses
       - run:
-          name: Install Android SDK platform tools
-          command: sdkmanager "platform-tools"
+          name: Install Android SDK components
+          command: sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
 
   install-cocoapods-on-macos:
     steps:
@@ -405,6 +405,74 @@ jobs:
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
 
+  run-maestro-e2e-tests-ios:
+    macos:
+      xcode: 16.4.0
+    resource_class: m4pro.medium
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - checkout
+      - run:
+          name: Install JDK 21 for Gradle
+          command: |
+            brew install openjdk@21
+            sudo ln -sfn "$(brew --prefix openjdk@21)/libexec/openjdk.jdk" /Library/Java/JavaVirtualMachines/openjdk-21.jdk
+            echo 'export JAVA_HOME=$(/usr/libexec/java_home -v 21)' >> "$BASH_ENV"
+      - install-android-sdk-on-macos
+      - revenuecat/install-gem-mac-dependencies:
+          cache-version: v1
+      - restore-gradle-user-home-directory-from-cache
+      - restore-kotlin-native-compiler-from-cache
+      - revenuecat/install-maestro
+      - run:
+          name: Boot iOS Simulator
+          command: |
+            xcrun simctl boot "iPhone 16 Pro" || true
+            xcrun simctl bootstatus "iPhone 16 Pro" -b
+      - run:
+          name: Run Maestro E2E Tests (iOS)
+          command: bundle exec fastlane run_maestro_e2e_tests_ios
+          no_output_timeout: 15m
+      - save-gradle-user-home-directory-to-cache
+      - save-kotlin-native-compiler-to-cache
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output
+
+  run-maestro-e2e-tests-android:
+    machine:
+      image: android:2024.11.1
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Install Ruby and Bundler
+          command: |
+            gem install bundler
+            bundle install
+      - run:
+          name: Build Maestro app (Android)
+          command: bundle exec fastlane build_maestro_app_android
+          no_output_timeout: 15m
+      - android/create-avd:
+          avd-name: test-e2e
+          system-image: system-images;android-34;google_apis;x86_64
+          install: true
+      - android/start-emulator:
+          avd-name: test-e2e
+          post-emulator-launch-assemble-command: ""
+      - revenuecat/install-maestro
+      - run:
+          name: Run Maestro E2E Tests (Android)
+          command: bundle exec fastlane run_maestro_e2e_tests_android
+          no_output_timeout: 15m
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output
+
   create-github-release:
     description: "Creates a GitHub release for the current version"
     executor: ruby3
@@ -418,6 +486,30 @@ jobs:
           command: bundle exec fastlane github_release_current_version
 
 workflows:
+  maestro-e2e-tests-ios:
+    when:
+      or:
+        - and:
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ "maestro_e2e_tests", << pipeline.schedule.name >> ]
+    jobs:
+      - run-maestro-e2e-tests-ios:
+          context:
+            - maestro-e2e-tests
+            - e2e-tests
+
+  maestro-e2e-tests-android:
+    when:
+      or:
+        - and:
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ "maestro_e2e_tests", << pipeline.schedule.name >> ]
+    jobs:
+      - run-maestro-e2e-tests-android:
+          context:
+            - maestro-e2e-tests
+            - e2e-tests
+
   on-action-upgrade-hybrid-common:
     when:
       equal: [ upgrade-hybrid-common, << pipeline.parameters.action >> ]
@@ -460,6 +552,14 @@ workflows:
           # This would benefit from the incremental build output of build-libraries-android
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
+      - run-maestro-e2e-tests-ios:
+          context:
+            - maestro-e2e-tests
+            - e2e-tests
+      - run-maestro-e2e-tests-android:
+          context:
+            - maestro-e2e-tests
+            - e2e-tests
 
   on-main-branch:
     when:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,7 +133,7 @@ lane :run_maestro_e2e_tests_ios do |options|
   Dir.chdir("../e2e-tests/MaestroTestApp") do
     app_kt = "src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt"
     sh("sed -i '' 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' #{app_kt}")
-    sh("grep -q MAESTRO_TESTS_REVENUECAT_API_KEY #{app_kt} && echo 'ERROR: API key placeholder was not replaced' && exit 1 || true")
+    UI.user_error!("API key placeholder was not replaced in #{app_kt}") if File.read(app_kt).include?("MAESTRO_TESTS_REVENUECAT_API_KEY")
 
     # Workaround for CocoaPods Errno::ENOENT bug during Gradle's podInstall tasks.
     # When the CocoaPods CDN cache is empty, Gradle's pod install can fail with
@@ -172,7 +172,7 @@ lane :build_maestro_app_android do
   UI.user_error!("RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE is not set") if ENV["RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE"].to_s.empty?
   app_kt = "../e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt"
   sh("sed -i 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' #{app_kt}")
-  sh("grep -q MAESTRO_TESTS_REVENUECAT_API_KEY #{app_kt} && echo 'ERROR: API key placeholder was not replaced' && exit 1 || true")
+  UI.user_error!("API key placeholder was not replaced in #{app_kt}") if File.read(app_kt).include?("MAESTRO_TESTS_REVENUECAT_API_KEY")
   sh("cd .. && ./gradlew :e2e-tests:MaestroTestApp:assembleDebug")
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,6 +90,7 @@ lane :update_hybrid_common do |options|
     "models/models.podspec" => ["spec.dependency 'PurchasesHybridCommon', '{x}'"],
     "revenuecatui/revenuecatui.podspec" => ["spec.dependency 'PurchasesHybridCommonUI', '{x}'"],
     "iosApp/Podfile" => ["  pod 'PurchasesHybridCommon', '{x}'", "  pod 'PurchasesHybridCommonUI', '{x}'"],
+    "e2e-tests/MaestroTestApp/iosApp/Podfile" => ["  pod 'PurchasesHybridCommon', '{x}'", "  pod 'PurchasesHybridCommonUI', '{x}'"],
   }
 
   if dry_run
@@ -128,15 +129,6 @@ desc "Run maestro E2E tests on iOS"
 lane :run_maestro_e2e_tests_ios do
   Dir.chdir("../e2e-tests/MaestroTestApp") do
     sh("sed -i '' 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt")
-
-    phc_version = File.read("../../gradle/libs.versions.toml")
-      .match(/revenuecat-common = "(.*)"/)[1]
-    UI.important("Syncing Podfile to PHC version #{phc_version}...")
-    podfile_content = File.read("iosApp/Podfile")
-    podfile_content.gsub!(/pod 'PurchasesHybridCommon',\s*'[^']*'/, "pod 'PurchasesHybridCommon', '#{phc_version}'")
-    podfile_content.gsub!(/pod 'PurchasesHybridCommonUI',\s*'[^']*'/, "pod 'PurchasesHybridCommonUI', '#{phc_version}'")
-    File.write("iosApp/Podfile", podfile_content)
-
     sh("pod cache clean --all")
     sh("rm -rf ~/Library/Caches/CocoaPods/Pods")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,9 +150,7 @@ lane :run_maestro_e2e_tests_ios do
     sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MaestroTestApp.app")
   end
   sh("mkdir -p test_output")
-  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/ 2>&1 || true")
-  sh("echo '=== Simulator logs (last 3 min) ===' && xcrun simctl spawn booted log show --predicate 'processImagePath CONTAINS \"MaestroTestApp\" OR eventMessage CONTAINS \"MaestroTestApp\"' --last 3m --style compact 2>/dev/null | tail -100 || echo 'No logs found'")
-  sh("test -f test_output/report.xml && grep -c 'failures=\"0\"' test_output/report.xml && echo 'TESTS PASSED' || (echo 'TESTS FAILED' && exit 1)")
+  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
 end
 
 desc "Build maestro E2E test app for Android"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -124,6 +124,50 @@ lane :update_hybrid_common do |options|
   end
 end
 
+desc "Run maestro E2E tests on iOS"
+lane :run_maestro_e2e_tests_ios do
+  Dir.chdir("../e2e-tests/MaestroTestApp") do
+    sh("sed -i '' 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt")
+    sh("pod cache clean --all")
+    sh("rm -rf ~/Library/Caches/CocoaPods/Pods")
+
+    UI.important("Pre-warming CocoaPods cache to avoid Errno::ENOENT during Gradle pod install...")
+    sh("mkdir -p /tmp/pod-warmup")
+    sh("cd /tmp/pod-warmup && cat > Podfile << 'PODEOF'\nsource 'https://cdn.cocoapods.org'\nplatform :ios, '13.0'\ntarget 'Warmup' do\n  use_frameworks!\n  pod 'PurchasesHybridCommon', '~> 17.0'\n  pod 'PurchasesHybridCommonUI', '~> 17.0'\nend\nPODEOF")
+    sh("cd /tmp/pod-warmup && pod install --no-integrate 2>&1 || true")
+
+    gradle_opts = "--init-script e2e-tests/MaestroTestApp/disable-x64.init.gradle.kts --no-parallel --max-workers=1 --no-daemon --no-configuration-cache"
+
+    UI.important("Running Gradle pod install tasks (init script patches AppIcon settings in doLast)...")
+    sh("cd ../.. && ./gradlew :revenuecatui:podInstallSyntheticIos :models:podInstallSyntheticIos :mappings:podInstallSyntheticIos :core:podInstallSyntheticIos #{gradle_opts}")
+
+    UI.important("Installing CocoaPods for iosApp...")
+    sh("cd iosApp && pod install --repo-update")
+
+    UI.important("Building with xcodebuild (using workspace)...")
+    sh("xcodebuild -workspace iosApp/iosApp.xcworkspace -scheme iosApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -derivedDataPath build CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES ARCHS=arm64 ENABLE_DEBUG_DYLIB=NO ASSETCATALOG_COMPILER_APPICON_NAME=")
+
+    sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MaestroTestApp.app")
+  end
+  sh("mkdir -p test_output")
+  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/ 2>&1 || true")
+  sh("echo '=== Simulator logs (last 3 min) ===' && xcrun simctl spawn booted log show --predicate 'processImagePath CONTAINS \"MaestroTestApp\" OR eventMessage CONTAINS \"MaestroTestApp\"' --last 3m --style compact 2>/dev/null | tail -100 || echo 'No logs found'")
+  sh("test -f test_output/report.xml && grep -c 'failures=\"0\"' test_output/report.xml && echo 'TESTS PASSED' || (echo 'TESTS FAILED' && exit 1)")
+end
+
+desc "Build maestro E2E test app for Android"
+lane :build_maestro_app_android do
+  sh("sed -i 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' ../e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt")
+  sh("cd .. && ./gradlew :e2e-tests:MaestroTestApp:assembleDebug")
+end
+
+desc "Run maestro E2E tests on Android (emulator must be running)"
+lane :run_maestro_e2e_tests_android do
+  sh("adb install ../e2e-tests/MaestroTestApp/build/outputs/apk/debug/MaestroTestApp-debug.apk")
+  sh("mkdir -p test_output")
+  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+end
+
 desc "Opens a PR updating the SDK version to the next minor, appending -SNAPSHOT."
 lane :prepare_next_snapshot_version do |options|
   create_next_snapshot_version(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,6 +128,15 @@ desc "Run maestro E2E tests on iOS"
 lane :run_maestro_e2e_tests_ios do
   Dir.chdir("../e2e-tests/MaestroTestApp") do
     sh("sed -i '' 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt")
+
+    phc_version = File.read("../../gradle/libs.versions.toml")
+      .match(/revenuecat-common = "(.*)"/)[1]
+    UI.important("Syncing Podfile to PHC version #{phc_version}...")
+    podfile_content = File.read("iosApp/Podfile")
+    podfile_content.gsub!(/pod 'PurchasesHybridCommon',\s*'[^']*'/, "pod 'PurchasesHybridCommon', '#{phc_version}'")
+    podfile_content.gsub!(/pod 'PurchasesHybridCommonUI',\s*'[^']*'/, "pod 'PurchasesHybridCommonUI', '#{phc_version}'")
+    File.write("iosApp/Podfile", podfile_content)
+
     sh("pod cache clean --all")
     sh("rm -rf ~/Library/Caches/CocoaPods/Pods")
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,13 +126,25 @@ lane :update_hybrid_common do |options|
 end
 
 desc "Run maestro E2E tests on iOS"
-lane :run_maestro_e2e_tests_ios do
+lane :run_maestro_e2e_tests_ios do |options|
+  simulator_name = options[:simulator_name] || "iPhone 16 Pro"
+
   Dir.chdir("../e2e-tests/MaestroTestApp") do
-    sh("sed -i '' 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt")
+    app_kt = "src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt"
+    sh("sed -i '' 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' #{app_kt}")
+    sh("grep -q MAESTRO_TESTS_REVENUECAT_API_KEY #{app_kt} && echo 'ERROR: API key placeholder was not replaced' && exit 1 || true")
+
+    # Workaround for CocoaPods Errno::ENOENT bug during Gradle's podInstall tasks.
+    # When the CocoaPods CDN cache is empty, Gradle's pod install can fail with
+    # `Errno::ENOENT - No such file or directory @ rb_sysopen` because the cache
+    # directory structure doesn't exist yet. Pre-warming with a throwaway pod install
+    # populates the CDN index and cache directories so the real install succeeds.
+    # Observed with CocoaPods 1.16.x on macOS CI runners.
+    # See: https://github.com/CocoaPods/CocoaPods/issues/9226
+    # This can likely be removed if CocoaPods fixes the cache initialization or if
+    # we move away from CocoaPods for dependency management.
     sh("pod cache clean --all")
     sh("rm -rf ~/Library/Caches/CocoaPods/Pods")
-
-    UI.important("Pre-warming CocoaPods cache to avoid Errno::ENOENT during Gradle pod install...")
     sh("mkdir -p /tmp/pod-warmup")
     sh("cd /tmp/pod-warmup && cat > Podfile << 'PODEOF'\nsource 'https://cdn.cocoapods.org'\nplatform :ios, '13.0'\ntarget 'Warmup' do\n  use_frameworks!\n  pod 'PurchasesHybridCommon', '~> 17.0'\n  pod 'PurchasesHybridCommonUI', '~> 17.0'\nend\nPODEOF")
     sh("cd /tmp/pod-warmup && pod install --no-integrate 2>&1 || true")
@@ -146,7 +158,7 @@ lane :run_maestro_e2e_tests_ios do
     sh("cd iosApp && pod install --repo-update")
 
     UI.important("Building with xcodebuild (using workspace)...")
-    sh("xcodebuild -workspace iosApp/iosApp.xcworkspace -scheme iosApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -derivedDataPath build CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES ARCHS=arm64 ENABLE_DEBUG_DYLIB=NO ASSETCATALOG_COMPILER_APPICON_NAME=")
+    sh("xcodebuild -workspace iosApp/iosApp.xcworkspace -scheme iosApp -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=#{simulator_name}' -derivedDataPath build CODE_SIGNING_ALLOWED=NO ONLY_ACTIVE_ARCH=YES ARCHS=arm64 ENABLE_DEBUG_DYLIB=NO ASSETCATALOG_COMPILER_APPICON_NAME=")
 
     sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MaestroTestApp.app")
   end
@@ -156,7 +168,9 @@ end
 
 desc "Build maestro E2E test app for Android"
 lane :build_maestro_app_android do
-  sh("sed -i 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' ../e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt")
+  app_kt = "../e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt"
+  sh("sed -i 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' #{app_kt}")
+  sh("grep -q MAESTRO_TESTS_REVENUECAT_API_KEY #{app_kt} && echo 'ERROR: API key placeholder was not replaced' && exit 1 || true")
   sh("cd .. && ./gradlew :e2e-tests:MaestroTestApp:assembleDebug")
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,7 +155,10 @@ lane :run_maestro_e2e_tests_ios do
     sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
   ensure
     UI.important("Capturing simulator logs for diagnostics...")
-    sh("xcrun simctl spawn booted log show --predicate 'processImagePath CONTAINS \"MaestroTestApp\" OR eventMessage CONTAINS \"MaestroTestApp\"' --last 5m --style compact 2>/dev/null | tail -300 || echo 'No simulator logs found'")
+    sh("xcrun simctl spawn booted log show --predicate 'process == \"MaestroTestApp\"' --last 5m --style compact 2>/dev/null | tail -500 || echo 'No simulator logs found'")
+    UI.important("Checking for crash reports...")
+    sh("ls -la ~/Library/Logs/DiagnosticReports/MaestroTestApp* 2>/dev/null || echo 'No crash reports found'")
+    sh("cat ~/Library/Logs/DiagnosticReports/MaestroTestApp*.ips 2>/dev/null | head -200 || echo 'No crash report content'")
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,6 +127,7 @@ end
 
 desc "Run maestro E2E tests on iOS"
 lane :run_maestro_e2e_tests_ios do |options|
+  UI.user_error!("RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE is not set") if ENV["RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE"].to_s.empty?
   simulator_name = options[:simulator_name] || "iPhone 16 Pro"
 
   Dir.chdir("../e2e-tests/MaestroTestApp") do
@@ -168,6 +169,7 @@ end
 
 desc "Build maestro E2E test app for Android"
 lane :build_maestro_app_android do
+  UI.user_error!("RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE is not set") if ENV["RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE"].to_s.empty?
   app_kt = "../e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt"
   sh("sed -i 's/MAESTRO_TESTS_REVENUECAT_API_KEY/'\"$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE\"'/g' #{app_kt}")
   sh("grep -q MAESTRO_TESTS_REVENUECAT_API_KEY #{app_kt} && echo 'ERROR: API key placeholder was not replaced' && exit 1 || true")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -151,15 +151,7 @@ lane :run_maestro_e2e_tests_ios do
     sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MaestroTestApp.app")
   end
   sh("mkdir -p test_output")
-  begin
-    sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
-  ensure
-    UI.important("Capturing simulator logs for diagnostics...")
-    sh("xcrun simctl spawn booted log show --predicate 'process == \"MaestroTestApp\"' --last 5m --style compact 2>/dev/null | tail -500 || echo 'No simulator logs found'")
-    UI.important("Checking for crash reports...")
-    sh("ls -la ~/Library/Logs/DiagnosticReports/MaestroTestApp* 2>/dev/null || echo 'No crash reports found'")
-    sh("cat ~/Library/Logs/DiagnosticReports/MaestroTestApp*.ips 2>/dev/null | head -200 || echo 'No crash report content'")
-  end
+  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
 end
 
 desc "Build maestro E2E test app for Android"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -151,7 +151,12 @@ lane :run_maestro_e2e_tests_ios do
     sh("xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/MaestroTestApp.app")
   end
   sh("mkdir -p test_output")
-  sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+  begin
+    sh("maestro test --format junit --output test_output/report.xml --test-output-dir test_output ../e2e-tests/maestro/")
+  ensure
+    UI.important("Capturing simulator logs for diagnostics...")
+    sh("xcrun simctl spawn booted log show --predicate 'processImagePath CONTAINS \"MaestroTestApp\" OR eventMessage CONTAINS \"MaestroTestApp\"' --last 5m --style compact 2>/dev/null | tail -300 || echo 'No simulator logs found'")
+  end
 end
 
 desc "Build maestro E2E test app for Android"


### PR DESCRIPTION
## Summary
- Adds a single `maestro-e2e-tests` CircleCI workflow triggered by the `maestro_e2e_tests` schedule, running both iOS and Android E2E jobs
- **E2E jobs also run on every PR push** (in the `on-non-release-branch` workflow), so regressions are caught before merge. This is the change with the biggest cost impact.
- Adds Fastlane lanes:
  - `run_maestro_e2e_tests_ios`: replaces API key placeholder (with verification), warms CocoaPods cache, builds via xcodebuild, installs on simulator, runs Maestro tests. Simulator name is parameterized to avoid breakage on Xcode updates.
  - `build_maestro_app_android` + `run_maestro_e2e_tests_android`: replaces API key placeholder (with verification), builds via Gradle, installs via adb, runs Maestro tests
- Both lanes use `$RC_E2E_TEST_API_KEY_PRODUCTION_TEST_STORE` from the `e2e-tests` CircleCI context
- Android E2E job includes Gradle cache restore/save for faster builds
- Test results stored as JUnit artifacts

Depends on #709