### PR TITLE
Fix CI clone failures after GitHub App migration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "upstream/purchases-ios"]
 	path = upstream/purchases-ios
-	url = git@github.com:RevenueCat/purchases-ios.git
+	url = https://github.com/RevenueCat/purchases-ios.git
 	branch = 5.60.0


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other hybrids

### Motivation

After migrating CircleCI from GitHub OAuth to GitHub App, CI jobs that initialize submodules fail because the deploy key is now scoped to this repo only. SSH URLs no longer have access to other org repos.

### Description

- Update `.gitmodules` to use HTTPS instead of SSH for the `purchases-ios` submodule

Sister PRs: https://github.com/RevenueCat/purchases-ios/pull/6399, purchases-android

Made with [Cursor](https://cursor.com)