### PR TITLE
Pin Ruby to 3.2.0 to fix iOS CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,17 @@ orbs:
   revenuecat: revenuecat/sdks-common-config@3.13.0
 
 commands:
+  pin-ruby-version:
+    steps:
+      - run:
+          name: Set Ruby 3.2.0
+          command: |
+            eval "$(rbenv init -)"
+            rbenv install -s 3.2.0
+            rbenv global 3.2.0
+            rbenv rehash
+            gem install cocoapods
+
   install-android-sdk-on-macos:
     description: Install the Android SDK on macOS
     steps:
@@ -132,6 +143,7 @@ jobs:
     executor: xcode16
     steps:
       - checkout
+      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - revenuecat/trust-github-key
@@ -214,6 +226,7 @@ jobs:
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
+      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - install-cocoapods-on-macos
@@ -255,6 +268,7 @@ jobs:
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
+      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - install-cocoapods-on-macos
@@ -294,6 +308,7 @@ jobs:
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
+      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - install-cocoapods-on-macos
@@ -369,6 +384,7 @@ jobs:
     steps:
       - checkout
       - install-android-sdk-on-macos
+      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - install-cocoapods-on-macos


### PR DESCRIPTION
## Summary
- Pins Ruby to 3.2.0 on all macOS CI jobs that use CocoaPods
- Installs CocoaPods in the pinned Ruby version since the Kotlin Gradle plugin calls `pod` directly via rbenv shims

Ruby 3.4.3 (shipped with the latest CircleCI macOS executor) changed `File.lstat` behavior, causing `Errno::ENOENT` during `podInstallSyntheticIos` tasks. This broke all iOS builds on CI, including `main`.

Inspired by the approach used in [purchases-react-native](https://github.com/RevenueCat/react-native-purchases), which also pins Ruby to 3.2.0 on macOS CI jobs.

Related: #747

## Test plan
- [x] Verified fix works on #747 CI run
- [x] Confirm `build-libraries-ios` passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)