### PR TITLE
Merge release PR after deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,3 +556,10 @@ workflows:
       - create-github-release:
           context: github-bot-public
           <<: *release-tags-job
+      - revenuecat/merge-release-pr:
+          repo_name: purchases-kmp
+          requires:
+            - publish
+            - create-github-release
+          context: github-bot-public
+          <<: *release-tags-job


### PR DESCRIPTION
## Motivation

After a release is deployed, the release PR should be automatically merged to avoid manual intervention and potential delays.

## Description

Adds a `revenuecat/merge-release-pr` job in the `on-release-tag` workflow that runs after `publish` and `create-github-release` complete to automatically merge the release PR.