### PR TITLE
Fixes caching of the Swift build tasks

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
@@ -51,7 +51,7 @@ private fun Project.configureAllSwiftDependencies(dependencies: List<SwiftDepend
         val targetSourceDir = packageInfo.getTargetSourceDir(dependency.target, dependency.packageDir)
         val swiftDependencies = packageInfo.getTargetDependencies(dependency.target)
         
-        configureSwiftDependency(kotlin, dependency, targetSourceDir, swiftDependencies)
+        configureSwiftDependency(kotlin, dependency, targetSourceDir, swiftDependencies, packageInfos)
         
         if (dependency.target !in resourcesConfigured) {
             configureSwiftResources(dependency, packageInfo)
@@ -112,7 +112,8 @@ private fun Project.configureSwiftDependency(
     kotlin: KotlinMultiplatformExtension,
     dependency: SwiftDependency,
     targetSourceDir: File,
-    swiftDependencies: List<String>
+    swiftDependencies: List<String>,
+    packageInfos: Map<File, SwiftPackageInfo>,
 ) {
     // Register a task to generate the cinterop .def file
     val defFile = layout.buildDirectory.file("generated/cinterop/${dependency.target}.def")
@@ -135,6 +136,15 @@ private fun Project.configureSwiftDependency(
             ?.takeIf { it.project != this  }
     }
 
+    // Add cross-project dependency source directories so the build cache is invalidated when a
+    // dependency target's source changes.
+    val transitiveDepSourceDirs = moduleDependencies.mapNotNull { dep ->
+        packageInfos[dep.dependency.packageDir]?.getTargetSourceDir(
+            targetName = dep.dependency.target,
+            packageDir = dep.dependency.packageDir
+        )
+    }
+
     kotlin.targets.withType<KotlinNativeTarget> {
         // Skip this target if it doesn't include the source set this dependency is added to.
         if (!includesSourceSet(dependency.sourceSetName)) return@withType
@@ -145,7 +155,13 @@ private fun Project.configureSwiftDependency(
         )
 
         val mainCompilation = compilations.getByName("main")
-        val swiftBuildTask = registerSwiftBuildTask(this, dependency, targetSourceDir)
+        val swiftBuildTask = registerSwiftBuildTask(
+            kotlinTarget = this,
+            dependency = dependency,
+            targetSourceDir = targetSourceDir,
+            transitiveDepSourceDirs = transitiveDepSourceDirs
+        )
+
         val swiftOutputDir = layout.buildDirectory
             .dir("swift-packages/${dependency.target}/${konanTarget.name}")
             .get().asFile
@@ -239,7 +255,8 @@ private fun KotlinNativeTarget.includesSourceSet(sourceSetName: String): Boolean
 private fun Project.registerSwiftBuildTask(
     kotlinTarget: KotlinNativeTarget,
     dependency: SwiftDependency,
-    targetSourceDir: File
+    targetSourceDir: File,
+    transitiveDepSourceDirs: List<File>,
 ): TaskProvider<SwiftBuildTask> {
     val taskSuffix = getTaskSuffix(kotlinTarget.konanTarget)
     val taskName = "compileSwift${dependency.target}$taskSuffix"
@@ -253,11 +270,13 @@ private fun Project.registerSwiftBuildTask(
         moduleName.set(dependency.moduleName)
         configuration.set(getSwiftConfiguration())
         packageDir.set(dependency.packageDir)
+        packageSwiftFile.set(dependency.packageDir.resolve("Package.swift"))
         this.targetSourceDir.set(targetSourceDir)
         outputDir.set(layout.buildDirectory.dir("swift-packages/${dependency.target}/${kotlinTarget.konanTarget.name}"))
         // Use a shared scratch directory at root project level for SPM build cache sharing
         scratchDir.set(rootProject.layout.buildDirectory.dir("swift-packages/.build"))
         swiftSettingsArgs.set(dependency.swiftSettings?.toCommandLineArgs() ?: emptyList())
+        this.transitiveDepSourceDirs.from(transitiveDepSourceDirs)
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/GenerateDefFileTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/GenerateDefFileTask.kt
@@ -4,6 +4,8 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
@@ -19,6 +21,7 @@ import java.security.MessageDigest
  * The .def file tells Kotlin/Native cinterop how to process the Swift-generated
  * Objective-C header and link against the static library.
  */
+@CacheableTask
 abstract class GenerateDefFileTask : DefaultTask() {
 
     /** The Kotlin package name for the generated bindings */
@@ -45,6 +48,7 @@ abstract class GenerateDefFileTask : DefaultTask() {
     /** The Swift source directory - used to compute a hash for cache invalidation */
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:IgnoreEmptyDirectories
     abstract val swiftSourceDir: DirectoryProperty
 
     /** The output .def file */

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/ProcessSwiftResourcesTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/ProcessSwiftResourcesTask.kt
@@ -7,6 +7,8 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
@@ -20,6 +22,7 @@ import javax.inject.Inject
 /**
  * Processes Swift package resources to include in the .klib via Compose Resources.
  */
+@CacheableTask
 abstract class ProcessSwiftResourcesTask @Inject constructor(
     private val execOperations: ExecOperations
 ) : DefaultTask() {
@@ -41,6 +44,7 @@ abstract class ProcessSwiftResourcesTask @Inject constructor(
      */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:IgnoreEmptyDirectories
     abstract val resourceFiles: ConfigurableFileCollection
 
     /**

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/SwiftBuildTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/SwiftBuildTask.kt
@@ -1,11 +1,17 @@
 package com.revenuecat.purchases.kmp.buildlogic.swift.task
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -22,6 +28,7 @@ import javax.inject.Inject
  * - An Objective-C header (-Swift.h)
  * - A module.modulemap for cinterop
  */
+@CacheableTask
 abstract class SwiftBuildTask @Inject constructor(
     private val execOperations: ExecOperations
 ) : DefaultTask() {
@@ -58,10 +65,26 @@ abstract class SwiftBuildTask @Inject constructor(
     @get:Internal
     abstract val packageDir: DirectoryProperty
 
+    /** The Package.swift file. Tracked for cache invalidation on package structure changes. */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val packageSwiftFile: RegularFileProperty
+
     /** The Swift target's source directory (for tracking incremental builds) */
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:IgnoreEmptyDirectories
     abstract val targetSourceDir: DirectoryProperty
+
+    /**
+     * Source directories of cross-project Swift target dependencies. Ensures the build cache
+     * is invalidated when a dependency target's source changes (e.g. RevenueCat sources
+     * affecting RevenueCatUI compilation).
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:IgnoreEmptyDirectories
+    abstract val transitiveDepSourceDirs: ConfigurableFileCollection
 
     /** The output directory for built artifacts */
     @get:OutputDirectory


### PR DESCRIPTION
## Issue
Both a Gradle Sync in Android Studio and any Gradle compilation task would compile the Swift source files, without reusing the output of each other. This only really affects local development, as Gradle Sync is not a thing that happens on CI. 

## Fix
The fix in this PR is to make all Gradle tasks responsible for building Swift a `@CacheableTask`. This has the effect that configuration cache misses no longer retrigger these tasks if their inputs (i.e. Swift source files) haven't changed.