### PR TITLE
Adds `iosApp` run config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.iml
 .gradle
 **/.idea/*
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-*.iml
 .gradle
-.idea
+**/.idea/*
 .DS_Store
 build
 captures
@@ -21,4 +20,8 @@ vendor/
 .bundle/
 
 # Share IssueNavigationConfiguration
-!.idea/vcs.xml
+!/.idea/vcs.xml
+# Ensure iosApp run configuration works
+!/.idea/xcode.xml
+!/.idea/purchases-kmp.iosApp.iml
+!/.idea/modules.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/com.revenuecat.purchases.purchases-kmp.iml" filepath="$PROJECT_DIR$/.idea/modules/com.revenuecat.purchases.purchases-kmp.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/apiTester/purchases-kmp.apiTester.iml" filepath="$PROJECT_DIR$/.idea/modules/apiTester/purchases-kmp.apiTester.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/composeApp/purchases-kmp.composeApp.main.iml" filepath="$PROJECT_DIR$/.idea/modules/composeApp/purchases-kmp.composeApp.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/core/purchases-kmp.core.iml" filepath="$PROJECT_DIR$/.idea/modules/core/purchases-kmp.core.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/purchases-kmp.iosApp.iml" filepath="$PROJECT_DIR$/.idea/purchases-kmp.iosApp.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/kn-core/purchases-kmp.kn-core.iml" filepath="$PROJECT_DIR$/.idea/modules/kn-core/purchases-kmp.kn-core.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/mappings/purchases-kmp.mappings.main.iml" filepath="$PROJECT_DIR$/.idea/modules/mappings/purchases-kmp.mappings.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/models/purchases-kmp.models.iml" filepath="$PROJECT_DIR$/.idea/modules/models/purchases-kmp.models.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/result/purchases-kmp.result.main.iml" filepath="$PROJECT_DIR$/.idea/modules/result/purchases-kmp.result.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/revenuecatui/purchases-kmp.revenuecatui.main.iml" filepath="$PROJECT_DIR$/.idea/modules/revenuecatui/purchases-kmp.revenuecatui.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/purchases-kmp.iosApp.iml
+++ b/.idea/purchases-kmp.iosApp.iml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module classpath="CIDR" type="CIDR_MODULE" version="4" />

--- a/.idea/xcode.xml
+++ b/.idea/xcode.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="XcodeMetaData" PROJECT_DIR="$PROJECT_DIR$/iosApp" PROJECT_FILE="$PROJECT_DIR$/iosApp/iosApp.xcodeproj" />
+</project>

--- a/.run/iosApp.run.xml
+++ b/.run/iosApp.run.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iosApp" type="AppleRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="iosApp" TARGET_NAME="iosApp" CONFIG_NAME="Debug" IS_LOCATION_SIMULATION_SUPPORTED="true" SCHEME_NAME="iosApp" IS_LOCATION_SIMULATION_ALLOWED="true" LOCATION_SCENARIO_ID="com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier" LOCATION_SCENARIO_TYPE="1" APPLICATION_LANGUAGE="IDELaunchSchemeLanguageUseSystemLanguage" APPLICATION_REGION="" DEVELOPMENT_TEAM="8SXR2327BM" RUN_TARGET_PROJECT_NAME="iosApp" RUN_TARGET_NAME="iosApp" MAKE_ACTIVE="TRUE" SHOULD_DEBUG_EXTENSIONS="false">
+    <embedded_app_extension_list />
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7555FF7A242A565900829871"
+               BuildableName = "purchases-kmp Sample.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7555FF7A242A565900829871"
+            BuildableName = "purchases-kmp Sample.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Description
The [Kotlin Multiplatform plugin for Android Studio](https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform) enables building the iOS tester app from Android Studio:  
  
<img width="408" height="34" alt="afbeelding" src="https://github.com/user-attachments/assets/a263d9eb-95ef-4711-a212-da264727c030" />

However, this wasn't working consistently. On top of that we've made some changes to the tester app due to the removal of CocoaPods, which might have broken it further. 

This PR adds the generated run configuration (`.run/iosApp.run.xml`) to the repo, including some other files on which this functionality depends. We'll have to see how stable these files are. In any case this should hopefully make this work much more consistently for everyone. 


