### PR TITLE
Fix flaky build-libraries-ios by serializing pod installs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
 parameters:
   action:
     type: enum
-    enum: [ build, upgrade-hybrid-common, bump ]
+    enum: [ build, upgrade-hybrid-common, bump, stress-test-ios ]
     default: build
   automatic:
     type: boolean
@@ -436,6 +436,32 @@ jobs:
           command: bundle exec fastlane github_release_current_version
 
 workflows:
+  # TEMP: Stress test for pod install fix. Remove before merging.
+  stress-test-build-libraries-ios:
+    when:
+      equal: [ stress-test-ios, << pipeline.parameters.action >> ]
+    jobs:
+      - build-libraries-ios:
+          name: build-libraries-ios-1
+      - build-libraries-ios:
+          name: build-libraries-ios-2
+      - build-libraries-ios:
+          name: build-libraries-ios-3
+      - build-libraries-ios:
+          name: build-libraries-ios-4
+      - build-libraries-ios:
+          name: build-libraries-ios-5
+      - build-libraries-ios:
+          name: build-libraries-ios-6
+      - build-libraries-ios:
+          name: build-libraries-ios-7
+      - build-libraries-ios:
+          name: build-libraries-ios-8
+      - build-libraries-ios:
+          name: build-libraries-ios-9
+      - build-libraries-ios:
+          name: build-libraries-ios-10
+
   on-action-upgrade-hybrid-common:
     when:
       equal: [ upgrade-hybrid-common, << pipeline.parameters.action >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
     description: >
       Run podInstallSyntheticIos for all Kotlin modules sequentially.
       Parallel pod installs race on the shared CocoaPods cache, causing
-      Errno::ENOENT failures. Running them first with --no-parallel
+      Errno::ENOENT failures. Running them first with --max-workers=1
       lets the subsequent compile step skip them (UP-TO-DATE).
     steps:
       - run:
@@ -70,7 +70,7 @@ commands:
               :mappings:podInstallSyntheticIos \
               :core:podInstallSyntheticIos \
               :revenuecatui:podInstallSyntheticIos \
-              --no-parallel
+              --no-parallel --max-workers=1
 
   save-kotlin-native-compiler-to-cache:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,15 @@ jobs:
           cache-version: v1
       - install-cocoapods-on-macos
       - run:
+          name: Pre-install CocoaPods for Kotlin modules
+          command: |
+            ./gradlew \
+              :models:podInstallSyntheticIos \
+              :mappings:podInstallSyntheticIos \
+              :core:podInstallSyntheticIos \
+              :revenuecatui:podInstallSyntheticIos \
+              --no-parallel
+      - run:
           name: Build libraries for iOS
           command: |
             tasks=()

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,23 @@ commands:
           command: bundle exec pod install --repo-update
           working_directory: iosApp
 
+  pre-install-pods-for-kotlin-modules:
+    description: >
+      Run podInstallSyntheticIos for all Kotlin modules sequentially.
+      Parallel pod installs race on the shared CocoaPods cache, causing
+      Errno::ENOENT failures. Running them first with --no-parallel
+      lets the subsequent compile step skip them (UP-TO-DATE).
+    steps:
+      - run:
+          name: Pre-install CocoaPods for Kotlin modules
+          command: |
+            ./gradlew \
+              :models:podInstallSyntheticIos \
+              :mappings:podInstallSyntheticIos \
+              :core:podInstallSyntheticIos \
+              :revenuecatui:podInstallSyntheticIos \
+              --no-parallel
+
   save-kotlin-native-compiler-to-cache:
     steps:
       - run:
@@ -230,15 +247,7 @@ jobs:
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - install-cocoapods-on-macos
-      - run:
-          name: Pre-install CocoaPods for Kotlin modules
-          command: |
-            ./gradlew \
-              :models:podInstallSyntheticIos \
-              :mappings:podInstallSyntheticIos \
-              :core:podInstallSyntheticIos \
-              :revenuecatui:podInstallSyntheticIos \
-              --no-parallel
+      - pre-install-pods-for-kotlin-modules
       - run:
           name: Build libraries for iOS
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
 parameters:
   action:
     type: enum
-    enum: [ build, upgrade-hybrid-common, bump, stress-test-ios ]
+    enum: [ build, upgrade-hybrid-common, bump ]
     default: build
   automatic:
     type: boolean
@@ -436,32 +436,6 @@ jobs:
           command: bundle exec fastlane github_release_current_version
 
 workflows:
-  # TEMP: Stress test for pod install fix. Remove before merging.
-  stress-test-build-libraries-ios:
-    when:
-      equal: [ stress-test-ios, << pipeline.parameters.action >> ]
-    jobs:
-      - build-libraries-ios:
-          name: build-libraries-ios-1
-      - build-libraries-ios:
-          name: build-libraries-ios-2
-      - build-libraries-ios:
-          name: build-libraries-ios-3
-      - build-libraries-ios:
-          name: build-libraries-ios-4
-      - build-libraries-ios:
-          name: build-libraries-ios-5
-      - build-libraries-ios:
-          name: build-libraries-ios-6
-      - build-libraries-ios:
-          name: build-libraries-ios-7
-      - build-libraries-ios:
-          name: build-libraries-ios-8
-      - build-libraries-ios:
-          name: build-libraries-ios-9
-      - build-libraries-ios:
-          name: build-libraries-ios-10
-
   on-action-upgrade-hybrid-common:
     when:
       equal: [ upgrade-hybrid-common, << pipeline.parameters.action >> ]


### PR DESCRIPTION
## Summary
- Fixes the intermittent `build-libraries-ios` CI failure caused by a CocoaPods cache race condition
- Gradle runs `podInstallSyntheticIos` for `core`, `models`, `mappings`, and `revenuecatui` in parallel. All four hit the shared `~/Library/Caches/CocoaPods/Pods/` directory concurrently, causing `Errno::ENOENT` errors during `cp_r` (e.g. `No such file or directory @ rb_file_s_lstat`)
- Adds a dedicated step that runs the pod install tasks with `--no-parallel` before the main build. The compile tasks still run fully parallel since pods are already installed (UP-TO-DATE)

## Test plan
- [x] Verify the `build-libraries-ios` job passes on this branch's CI run. Stress tested [here](https://app.circleci.com/pipelines/github/RevenueCat/purchases-kmp/2856). 20 runs, 0 failures.

Made with [Cursor](https://cursor.com)