### PR TITLE
Skip test cases list in maestro tests using launch arguments

### DIFF
--- a/e2e-tests/MaestroTestApp/iosApp/iosApp/ContentView.swift
+++ b/e2e-tests/MaestroTestApp/iosApp/iosApp/ContentView.swift
@@ -3,16 +3,20 @@ import SwiftUI
 import ComposeApp
 
 struct ComposeView: UIViewControllerRepresentable {
+    var testFlow: String?
+
     func makeUIViewController(context: Context) -> UIViewController {
-        MainViewControllerKt.MainViewController()
+        MainViewControllerKt.MainViewController(testFlow: testFlow)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
 }
 
 struct ContentView: View {
+    var testFlow: String?
+
     var body: some View {
-        ComposeView()
+        ComposeView(testFlow: testFlow)
             .ignoresSafeArea(.keyboard)
     }
 }

--- a/e2e-tests/MaestroTestApp/iosApp/iosApp/iOSApp.swift
+++ b/e2e-tests/MaestroTestApp/iosApp/iosApp/iOSApp.swift
@@ -2,9 +2,13 @@ import SwiftUI
 
 @main
 struct MaestroTestAppIOSApp: App {
+    private var testFlow: String? {
+        UserDefaults.standard.string(forKey: "e2e_test_flow")
+    }
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(testFlow: testFlow)
         }
     }
 }

--- a/e2e-tests/MaestroTestApp/src/androidMain/kotlin/com/revenuecat/automatedsdktests/MainActivity.kt
+++ b/e2e-tests/MaestroTestApp/src/androidMain/kotlin/com/revenuecat/automatedsdktests/MainActivity.kt
@@ -15,8 +15,9 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         Purchases.logLevel = LogLevel.DEBUG
         Purchases.configure(PurchasesConfiguration(API_KEY))
+        val testFlow = intent.getStringExtra("e2e_test_flow")
         setContent {
-            App()
+            App(initialTestFlow = testFlow)
         }
     }
 }

--- a/e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt
+++ b/e2e-tests/MaestroTestApp/src/commonMain/kotlin/com/revenuecat/maestro/e2e/App.kt
@@ -11,9 +11,14 @@ const val API_KEY = "MAESTRO_TESTS_REVENUECAT_API_KEY"
 
 enum class Screen { TestCases, PurchaseThroughPaywall }
 
+private val testFlowScreenMap = mapOf(
+    "purchase_through_paywall" to Screen.PurchaseThroughPaywall,
+)
+
 @Composable
-fun App() {
-    var currentScreen by remember { mutableStateOf(Screen.TestCases) }
+fun App(initialTestFlow: String? = null) {
+    val initialScreen = initialTestFlow?.let { testFlowScreenMap[it] } ?: Screen.TestCases
+    var currentScreen by remember { mutableStateOf(initialScreen) }
 
     MaterialTheme {
         when (currentScreen) {

--- a/e2e-tests/MaestroTestApp/src/iosMain/kotlin/com/revenuecat/maestro/e2e/MainViewController.kt
+++ b/e2e-tests/MaestroTestApp/src/iosMain/kotlin/com/revenuecat/maestro/e2e/MainViewController.kt
@@ -6,8 +6,8 @@ import com.revenuecat.purchases.kmp.Purchases
 import com.revenuecat.purchases.kmp.PurchasesConfiguration
 
 @Suppress("unused", "FunctionName")
-fun MainViewController(): platform.UIKit.UIViewController {
+fun MainViewController(testFlow: String? = null): platform.UIKit.UIViewController {
     Purchases.logLevel = LogLevel.DEBUG
     Purchases.configure(PurchasesConfiguration(API_KEY))
-    return ComposeUIViewController { App() }
+    return ComposeUIViewController { App(initialTestFlow = testFlow) }
 }

--- a/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
+++ b/e2e-tests/maestro/e2e_tests/purchase_through_paywall.yaml
@@ -8,16 +8,12 @@ name: Purchase through paywall
 ---
 - clearState
 - pressKey: home
-- launchApp
-- extendedWaitUntil:
-    visible: "Test Cases"
-    timeout: 30000
-- assertVisible: "Test Cases"
-- tapOn:
-    text: "Purchase through paywall"
+- launchApp:
+    arguments:
+        e2e_test_flow: purchase_through_paywall
 - extendedWaitUntil:
     visible: "Entitlements: none"
-    timeout: 15000
+    timeout: 30000
 - assertVisible: "Entitlements: none"
 - assertVisible: "Present Paywall"
 - tapOn:


### PR DESCRIPTION
## Summary
- Pass `e2e_test_flow` as a Maestro `launchApp` argument so the app navigates directly to the target test case screen, bypassing the Test Cases list
- On Android, reads from intent extras; on iOS, reads from UserDefaults and passes through SwiftUI → KMP Compose
- Makes maestro tests faster by skipping the list navigation step
- The Test Cases list is preserved for manual/local usage

## Related PRs
- https://github.com/RevenueCat/react-native-purchases/pull/1722
- https://github.com/RevenueCat/purchases-flutter/pull/1714
- https://github.com/RevenueCat/purchases-capacitor/pull/757
- https://github.com/RevenueCat/cordova-plugin-purchases/pull/919
- https://github.com/RevenueCat/purchases-unity/pull/897

Follows the same pattern as the iOS SDK's maestro app (`purchases-ios/Examples/rc-maestro`).