### PR TITLE
Adds `datetime` module removal to migration guide

### DIFF
--- a/migrations/3.0.0-MIGRATION.md
+++ b/migrations/3.0.0-MIGRATION.md
@@ -32,5 +32,13 @@ pod("PurchasesHybridCommonUI") {
 } 
 ```
 
+## Remove purchases-kmp-datetime
+The `purchases-kmp-datetime` library is removed as its functionality has been included in the main `purchases-kmp` library for some time. If you are still using `purchases-kmp-datetime`, please follow these steps to migrate:
+1. Find any usages of `*Instant` extension properties in your code, e.g. `firstSeenInstant`.
+2. Use Android Studio's automatic replacement functionality to replace its usage with the equivalent property in `purchases-kmp`, e.g. `firstSeen`.
+3. Opt in to using experimental time APIs, using `@OptIn(ExperimentalTime::class)`.
+4. Make sure you're importing `kotlin.time.Instant` instead of `kotlinx.datetime.Instant`. 
+5. Remove the `purchases-kmp-datetime` dependency from your project.
+
 ## Reporting undocumented issues:
 Feel free to file an issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-kmp/issues/new/). Make sure to state clearly that you're using version 3.0.0. Thanks!


### PR DESCRIPTION
## Description
As the title says.