### PR TITLE
Removes unnecessary CI steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,17 +21,6 @@ orbs:
   revenuecat: revenuecat/sdks-common-config@3.16.0
 
 commands:
-  pin-ruby-version:
-    steps:
-      - run:
-          name: Set Ruby 3.2.0
-          command: |
-            eval "$(rbenv init -)"
-            rbenv install -s 3.2.0
-            rbenv global 3.2.0
-            rbenv rehash
-            gem install cocoapods
-
   install-android-sdk-on-macos:
     description: Install the Android SDK on macOS
     steps:
@@ -211,7 +200,6 @@ jobs:
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
-      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
@@ -253,7 +241,6 @@ jobs:
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
-      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
@@ -302,7 +289,6 @@ jobs:
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
-      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
@@ -380,7 +366,6 @@ jobs:
       - checkout
       - checkout-submodule
       - install-android-sdk-on-macos
-      - pin-ruby-version
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - restore-gradle-user-home-directory-from-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,6 @@ jobs:
           command: ./gradlew apiCheck
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   build-libraries-android:
     executor: android202409
@@ -231,7 +230,6 @@ jobs:
             done
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   build-sample-ios:
     executor: xcode16
@@ -262,7 +260,6 @@ jobs:
               build;
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   public-api-tests-android:
     executor: android202409
@@ -279,7 +276,6 @@ jobs:
             done
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   public-api-tests-ios:
     executor: xcode16
@@ -301,7 +297,6 @@ jobs:
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   unit-tests-android:
     executor: android202409
@@ -318,7 +313,6 @@ jobs:
             done
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   unit-tests-ios:
     executor: xcode16
@@ -338,7 +332,6 @@ jobs:
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
-      - save-incremental-gradle-build-to-workspace
 
   unit-tests-build-logic:
     executor: xcode16


### PR DESCRIPTION
## Description
- `pin-ruby-version` is no longer needed, as that was a fix for a CocoaPods issue.
- There's no point in writing to the workspace when there's no subsequent job using that workspace.

Both of these steps were significant. Removing them shaves of 2+ minutes of a typical workflow run, meaning it now gets close to (sometimes under) 10 minutes. 