### PR TITLE
Bypass Test Store Release-build crash in purchases-ios

### DIFF
--- a/kn-core/build.gradle.kts
+++ b/kn-core/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.revenuecat.purchases.kmp.buildlogic.swift.model.SwiftSettings
 import com.revenuecat.purchases.kmp.buildlogic.swift.swiftPackage
 
 plugins {
@@ -16,7 +17,14 @@ kotlin {
                     static inline int __forceBindings(
                         enum RCStoreMessageType _1
                     ) { return 0; }
-                """.trimIndent()
+                """.trimIndent(),
+                // Bypass purchases-ios' Test Store Release-build crash. purchases-kmp distributes
+                // purchases-ios as a pre-compiled binary built in Release configuration, so the
+                // safeguard would otherwise crash apps using a Test Store API key during
+                // development. See https://github.com/RevenueCat/purchases-kmp/issues/823.
+                swiftSettings = SwiftSettings {
+                    define("BYPASS_SIMULATED_STORE_RELEASE_CHECK")
+                }
             )
 
             swiftPackage(


### PR DESCRIPTION
Part of SDK-4295

### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other hybrids

### Motivation

In `purchases-kmp` v3.0.0 (currently in beta), `purchases-ios` ships as a pre-compiled static library inside the published Kotlin/Native artifacts, **always built in Release**. As a result, any app using `purchases-kmp` v3 with a Test Store API key crashes at `configure` time on iOS.

Resolves #823

**Depends on**: https://github.com/RevenueCat/purchases-ios/pull/6710

### Description

- Defines the `BYPASS_SIMULATED_STORE_RELEASE_CHECK` Swift compilation flag introduced in https://github.com/RevenueCat/purchases-ios/pull/6710 when building the bundled `RevenueCat` target in `kn-core/build.gradle.kts`. With this flag set, the iOS SDK skips the Release-build safeguard that would otherwise crash apps using a Test Store API key.

### Trade-off

Apps shipped to production with a Test Store API key won't be caught at runtime on iOS. Ideally we'd detect at runtime whether the app is in TestFlight / App Review / Production and only fail there, but we haven't yet found a reliable way to do that (`AppTransaction.shared` can [trigger login prompts](https://github.com/RevenueCat/purchases-ios/pull/6154#issuecomment-4046405346) for users not signed in with their Apple account). The plan is to revisit a smarter detection in a follow-up.

### Testing

- `./gradlew :kn-core:assemble` builds successfully with the new flag, including the underlying `swift build` for the `RevenueCat` target across all iOS Apple targets.
- `./gradlew :core:assemble` builds successfully on top.
- Tested that Test Store is supported publishing to maven local

Made with [Cursor](https://cursor.com)