### PR TITLE
Migrates PostHog attribution from PHC to `kn-core`

### DIFF
--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -67,6 +67,7 @@ import swiftPMImport.com.revenuecat.purchases.kn.core.recordPurchaseForProductID
 import swiftPMImport.com.revenuecat.purchases.kn.core.setAirbridgeDeviceID
 import swiftPMImport.com.revenuecat.purchases.kn.core.setAirshipChannelID
 import swiftPMImport.com.revenuecat.purchases.kn.core.setOnesignalUserID
+import swiftPMImport.com.revenuecat.purchases.kn.core.setPostHogUserID
 import swiftPMImport.com.revenuecat.purchases.kn.core.showStoreMessagesForTypes
 import swiftPMImport.com.revenuecat.purchases.kn.core.trackCustomPaywallImpression
 import swiftPMImport.com.revenuecat.purchases.kn.core.RCDangerousSettings as IosDangerousSettings
@@ -652,7 +653,7 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         iosPurchases.attribution().setOnesignalUserID(onesignalUserID)
 
     public actual fun setPostHogUserID(postHogUserID: String?): Unit =
-        RCCommonFunctionality.setPostHogUserID(postHogUserID)
+        iosPurchases.attribution().setPostHogUserID(postHogUserID)
 
     public actual fun setAirshipChannelID(airshipChannelID: String?): Unit =
         iosPurchases.attribution().setAirshipChannelID(airshipChannelID)


### PR DESCRIPTION
## Description
Migrates https://github.com/RevenueCat/purchases-kmp/pull/837 to 3.0.0. 