### PR TITLE
Release/3.0.0

### DIFF
--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,21 +1,34 @@
-## RevenueCat SDK
 ### 💥 Breaking Changes
-* Updates purchases-android to 10.0.0 (#797) via JayShortway (@JayShortway)
-* Deletes the deprecated datetime module (#769) via JayShortway
-* Migrates more iOS features from PHC to kn-core and kn-ui (#767) via JayShortway
-* Migrates iOS from PHC to kn-core and kn-ui (#723) via JayShortway
+* This release updates to Billing Library 8.3.0 with min SDK supported of Android 6 (API 23), previously min was 21. It also removes a previous workaround used to be able to restore consumed one time products which is not available anymore.
+* This release removes the need to specify a version of purchases-hybrid-common. See our [migration guide](migrations/3.0.0-MIGRATION.md) for how to do this.
+* Removal of purchases-kmp-datetime dependency 
+* Updates Kotlin to version 2.3.20
+
+For more information, please check our [migration guide](migrations/3.0.0-MIGRATION.md)
+
+### ✨ New Features
+* Add PostHog user ID setter (#837) via Cesar de la Vega (@vegaro)
+
+### 📦 Dependency Updates
+* [RENOVATE] Update dependency gradle to v9.5.0 (#842) via Toni Rico (@tonidero)
+* [RENOVATE] Update purchases-android to v10.4.0 (#843) via Toni Rico (@tonidero)
+* [RENOVATE] Update dependency upstream/purchases-ios to v5.71.0 (#813) via RevenueCat Git Bot (@RCGitBot)
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.3.0 (#834) via RevenueCat Git Bot (@RCGitBot)
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.2.0 (#831) via RevenueCat Git Bot (@RCGitBot)
+* [RENOVATE] Update dependency upstream/purchases-ios to v5.67.2 (#805) via RevenueCat Git Bot (@RCGitBot)
 
 ### 🔄 Other Changes
-* No longer tries to update `podspec` files during release (#799) via JayShortway (@JayShortway)
-* Updates Fastlane `README.md` (#798) via JayShortway (@JayShortway)
-* Adds 3.0.0 migration guide (#793) via JayShortway
-* Adds iosApp run config (#785) via JayShortway
-* Fixes caching of the Swift build tasks (#780) via JayShortway
-* Removes dead code (#779) via JayShortway
-* Updates Compose Multiplatform to 1.9.3 (#778) via JayShortway
-* Updates Kotlin to 2.3.20 and Gradle to 9.4.1 (#771) via JayShortway
-* Fixes release automations (#770) via JayShortway
-* Migrates Android from PHC to purchases-android (#768) via JayShortway
-* Adds facade Gradle modules for Swift packages (#714) via JayShortway
-* Bump fastlane-plugin-revenuecat_internal from `6289be1` to `ceecf91` (#795)
-
+* Bump fastlane-plugin-revenuecat_internal from `21e02ec` to `af7bb5c` (#838) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `2d11430` to `21e02ec` (#835) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `d24ab26` to `2d11430` (#833) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane from 2.233.0 to 2.233.1 (#830) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `b822f01` to `d24ab26` (#822) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `e348913` to `b822f01` (#820) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane from 2.232.2 to 2.233.0 (#817) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `a1eed48` to `e348913` (#818) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `20911d1` to `a1eed48` (#812) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `894bb1b` to `20911d1` (#806) via dependabot[bot] (@dependabot[bot])
+* Update CODEOWNERS default owner to @RevenueCat/sdk (#803) via Antonio Pallares (@ajpallares)
+* Bump fastlane-plugin-revenuecat_internal from `ceecf91` to `894bb1b` (#804) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `6289be1` to `ceecf91` (#795) via dependabot[bot] (@dependabot[bot])
+* Fix flaky build-libraries-ios by serializing pod installs (#792) via Antonio Pallares (@ajpallares)

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -14,8 +14,6 @@ For more information, please check our [migration guide](migrations/3.0.0-MIGRAT
 * [RENOVATE] Update dependency gradle to v9.5.0 (#842) via Toni Rico (@tonidero)
 * [RENOVATE] Update purchases-android to v10.4.0 (#843) via Toni Rico (@tonidero)
 * [RENOVATE] Update dependency upstream/purchases-ios to v5.71.0 (#813) via RevenueCat Git Bot (@RCGitBot)
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.3.0 (#834) via RevenueCat Git Bot (@RCGitBot)
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.2.0 (#831) via RevenueCat Git Bot (@RCGitBot)
 * [RENOVATE] Update dependency upstream/purchases-ios to v5.67.2 (#805) via RevenueCat Git Bot (@RCGitBot)
 
 ### 🔄 Other Changes

--- a/CHANGELOG-LATEST.md
+++ b/CHANGELOG-LATEST.md
@@ -1,3 +1,4 @@
+## RevenueCat SDK
 ### 💥 Breaking Changes
 * This release updates to Billing Library 8.3.0 with min SDK supported of Android 6 (API 23), previously min was 21. It also removes a previous workaround used to be able to restore consumed one time products which is not available anymore.
 * This release removes the need to specify a version of purchases-hybrid-common. See our [migration guide](migrations/3.0.0-MIGRATION.md) for how to do this.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ For more information, please check our [migration guide](migrations/3.0.0-MIGRAT
 * [RENOVATE] Update dependency gradle to v9.5.0 (#842) via Toni Rico (@tonidero)
 * [RENOVATE] Update purchases-android to v10.4.0 (#843) via Toni Rico (@tonidero)
 * [RENOVATE] Update dependency upstream/purchases-ios to v5.71.0 (#813) via RevenueCat Git Bot (@RCGitBot)
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.3.0 (#834) via RevenueCat Git Bot (@RCGitBot)
-* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.2.0 (#831) via RevenueCat Git Bot (@RCGitBot)
 * [RENOVATE] Update dependency upstream/purchases-ios to v5.67.2 (#805) via RevenueCat Git Bot (@RCGitBot)
 
 ### 🔄 Other Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 3.0.0
+### 💥 Breaking Changes
+* This release updates to Billing Library 8.3.0 with min SDK supported of Android 6 (API 23), previously min was 21. It also removes a previous workaround used to be able to restore consumed one time products which is not available anymore.
+* This release removes the need to specify a version of purchases-hybrid-common. See our [migration guide](migrations/3.0.0-MIGRATION.md) for how to do this.
+* Removal of purchases-kmp-datetime dependency 
+* Updates Kotlin to version 2.3.20
+
+For more information, please check our [migration guide](migrations/3.0.0-MIGRATION.md)
+
+### ✨ New Features
+* Add PostHog user ID setter (#837) via Cesar de la Vega (@vegaro)
+
+### 📦 Dependency Updates
+* [RENOVATE] Update dependency gradle to v9.5.0 (#842) via Toni Rico (@tonidero)
+* [RENOVATE] Update purchases-android to v10.4.0 (#843) via Toni Rico (@tonidero)
+* [RENOVATE] Update dependency upstream/purchases-ios to v5.71.0 (#813) via RevenueCat Git Bot (@RCGitBot)
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.3.0 (#834) via RevenueCat Git Bot (@RCGitBot)
+* [AUTOMATIC BUMP] Updates purchases-hybrid-common to 18.2.0 (#831) via RevenueCat Git Bot (@RCGitBot)
+* [RENOVATE] Update dependency upstream/purchases-ios to v5.67.2 (#805) via RevenueCat Git Bot (@RCGitBot)
+
+### 🔄 Other Changes
+* Bump fastlane-plugin-revenuecat_internal from `21e02ec` to `af7bb5c` (#838) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `2d11430` to `21e02ec` (#835) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `d24ab26` to `2d11430` (#833) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane from 2.233.0 to 2.233.1 (#830) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `b822f01` to `d24ab26` (#822) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `e348913` to `b822f01` (#820) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane from 2.232.2 to 2.233.0 (#817) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `a1eed48` to `e348913` (#818) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `20911d1` to `a1eed48` (#812) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `894bb1b` to `20911d1` (#806) via dependabot[bot] (@dependabot[bot])
+* Update CODEOWNERS default owner to @RevenueCat/sdk (#803) via Antonio Pallares (@ajpallares)
+* Bump fastlane-plugin-revenuecat_internal from `ceecf91` to `894bb1b` (#804) via dependabot[bot] (@dependabot[bot])
+* Bump fastlane-plugin-revenuecat_internal from `6289be1` to `ceecf91` (#795) via dependabot[bot] (@dependabot[bot])
+* Fix flaky build-libraries-ios by serializing pod installs (#792) via Antonio Pallares (@ajpallares)
+
 ## 3.0.0-beta.1
 ## RevenueCat SDK
 ### 💥 Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 3.0.0
+## RevenueCat SDK
 ### 💥 Breaking Changes
 * This release updates to Billing Library 8.3.0 with min SDK supported of Android 6 (API 23), previously min was 21. It also removes a previous workaround used to be able to restore consumed one time products which is not available anymore.
 * This release removes the need to specify a version of purchases-hybrid-common. See our [migration guide](migrations/3.0.0-MIGRATION.md) for how to do this.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 | Version | iOS version | Android version | Common files version | Play Billing Library version |
 |---------|-------------|-----------------|----------------------|------------------------------|
+| 3.0.0 | [5.71.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.71.0) | [10.4.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.4.0) | N/A | [8.3.0](https://developer.android.com/google/play/billing/release-notes) |
 | 3.0.0-beta.1 | [5.67.1](https://github.com/RevenueCat/purchases-ios/releases/tag/5.67.1) | [10.0.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.0.0) | N/A | [8.3.0](https://developer.android.com/google/play/billing/release-notes) |
 | 2.10.2+17.55.1 | [5.67.1](https://github.com/RevenueCat/purchases-ios/releases/tag/5.67.1) | [9.29.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.29.0) | [17.55.1](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/17.55.1) | [8.0.0](https://developer.android.com/google/play/billing/release-notes) |
 | 2.10.1+17.54.0 | [5.67.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.67.0) | [9.28.1](https://github.com/RevenueCat/purchases-android/releases/tag/9.28.1) | [17.54.0](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/17.54.0) | [8.0.0](https://developer.android.com/google/play/billing/release-notes) |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ junit = "5.10.0"
 kotlin = "2.3.20"
 mavenPublish = "0.33.0"
 revenuecat-android = "10.4.0"
-revenuecat-kmp = "3.0.0-SNAPSHOT"
+revenuecat-kmp = "3.0.0"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }


### PR DESCRIPTION
## RevenueCat SDK
### 💥 Breaking Changes
* This release updates to Billing Library 8.3.0 with min SDK supported of Android 6 (API 23), previously min was 21. It also removes a previous workaround used to be able to restore consumed one time products which is not available anymore.
* This release removes the need to specify a version of purchases-hybrid-common. See our [migration guide](migrations/3.0.0-MIGRATION.md) for how to do this.
* Removal of purchases-kmp-datetime dependency 
* Updates Kotlin to version 2.3.20

For more information, please check our [migration guide](migrations/3.0.0-MIGRATION.md)

### ✨ New Features
* Add PostHog user ID setter (#837) via Cesar de la Vega (@vegaro)

### 📦 Dependency Updates
* [RENOVATE] Update dependency gradle to v9.5.0 (#842) via Toni Rico (@tonidero)
* [RENOVATE] Update purchases-android to v10.4.0 (#843) via Toni Rico (@tonidero)
* [RENOVATE] Update dependency upstream/purchases-ios to v5.71.0 (#813) via RevenueCat Git Bot (@RCGitBot)
* [RENOVATE] Update dependency upstream/purchases-ios to v5.67.2 (#805) via RevenueCat Git Bot (@RCGitBot)

### 🔄 Other Changes
* Bump fastlane-plugin-revenuecat_internal from `21e02ec` to `af7bb5c` (#838) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `2d11430` to `21e02ec` (#835) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `d24ab26` to `2d11430` (#833) via dependabot[bot] (@dependabot[bot])
* Bump fastlane from 2.233.0 to 2.233.1 (#830) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `b822f01` to `d24ab26` (#822) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `e348913` to `b822f01` (#820) via dependabot[bot] (@dependabot[bot])
* Bump fastlane from 2.232.2 to 2.233.0 (#817) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `a1eed48` to `e348913` (#818) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `20911d1` to `a1eed48` (#812) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `894bb1b` to `20911d1` (#806) via dependabot[bot] (@dependabot[bot])
* Update CODEOWNERS default owner to @RevenueCat/sdk (#803) via Antonio Pallares (@ajpallares)
* Bump fastlane-plugin-revenuecat_internal from `ceecf91` to `894bb1b` (#804) via dependabot[bot] (@dependabot[bot])
* Bump fastlane-plugin-revenuecat_internal from `6289be1` to `ceecf91` (#795) via dependabot[bot] (@dependabot[bot])
* Fix flaky build-libraries-ios by serializing pod installs (#792) via Antonio Pallares (@ajpallares)
