### PR TITLE
Pin CI to Xcode 26.0.1 for iOS Swift artifact compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ executors:
       - image: cimg/ruby:3.3.0
   xcode26:
     macos:
-      xcode: 26.4.1
+      xcode: 26.0.1
     resource_class: m4pro.medium
     environment:
       # Avoid waiting for Homebrew to auto update existing packages, as everything we care about is


### PR DESCRIPTION
### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other
  hybrids

### Motivation

Resolves #859. Maven 3.0.1 ships RevenueCatUI static libraries compiled on Xcode 26.4.1, which fail to link on Xcode 26.0.1. CI should publish from the oldest supported Xcode in the 26.x line.

### Description

- Pin the shared `xcode26` executor to Xcode 26.0.1, covering publish, iOS library builds, and `build-sample-ios`.
- Ensures precompiled Swift artifacts remain linkable for consumers on Xcode 26.0.x through 26.5.x.


Made with [Cursor](https://cursor.com)