### PR TITLE
Fix VERSIONS.md not updating on automatic releases

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,5 +1,6 @@
 | Version | iOS version | Android version | Common files version | Play Billing Library version |
 |---------|-------------|-----------------|----------------------|------------------------------|
+| 3.0.1 | [5.72.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.72.0) | [10.5.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.5.0) | N/A | [8.3.0](https://developer.android.com/google/play/billing/release-notes) |
 | 3.0.0 | [5.71.0](https://github.com/RevenueCat/purchases-ios/releases/tag/5.71.0) | [10.4.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.4.0) | N/A | [8.3.0](https://developer.android.com/google/play/billing/release-notes) |
 | 3.0.0-beta.1 | [5.67.1](https://github.com/RevenueCat/purchases-ios/releases/tag/5.67.1) | [10.0.0](https://github.com/RevenueCat/purchases-android/releases/tag/10.0.0) | N/A | [8.3.0](https://developer.android.com/google/play/billing/release-notes) |
 | 2.10.2+17.55.1 | [5.67.1](https://github.com/RevenueCat/purchases-ios/releases/tag/5.67.1) | [9.29.0](https://github.com/RevenueCat/purchases-android/releases/tag/9.29.0) | [17.55.1](https://github.com/RevenueCat/purchases-hybrid-common/releases/tag/17.55.1) | [8.0.0](https://developer.android.com/google/play/billing/release-notes) |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,8 +127,17 @@ def get_android_version
 end
 
 def get_ios_version
-  version = File.read("../upstream/purchases-ios/.version").strip
-  UI.user_error!("iOS version not found in upstream/purchases-ios/.version") if version.nil? || version.empty?
+  require 'base64'
+  submodule_sha = `git ls-tree HEAD upstream/purchases-ios`.split[2]
+  UI.user_error!("Could not read upstream/purchases-ios submodule commit from the parent tree") if submodule_sha.nil? || submodule_sha.empty?
+  response = github_api(
+    server_url: 'https://api.github.com',
+    api_token: ENV["GITHUB_TOKEN"],
+    http_method: 'GET',
+    path: "/repos/RevenueCat/purchases-ios/contents/.version?ref=#{submodule_sha}"
+  )
+  version = Base64.decode64(response[:json]['content']).strip
+  UI.user_error!("iOS version not found in upstream/purchases-ios/.version at #{submodule_sha}") if version.nil? || version.empty?
   version
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,6 +127,12 @@ def get_android_version
 end
 
 def get_ios_version
+  local_path = "../upstream/purchases-ios/.version"
+  if File.exist?(local_path)
+    version = File.read(local_path).strip
+    return version unless version.empty?
+  end
+
   require 'base64'
   submodule_sha = `git ls-tree HEAD upstream/purchases-ios`.split[2]
   UI.user_error!("Could not read upstream/purchases-ios submodule commit from the parent tree") if submodule_sha.nil? || submodule_sha.empty?


### PR DESCRIPTION
### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other hybrids

### Motivation

`VERSIONS.md` is missing the 3.0.1 row. The `automatic-bump` CircleCI job does not initialize submodules, so `get_ios_version` crashed with `Errno::ENOENT` reading `upstream/purchases-ios/.version`. The crash happens after the release PR has been pushed, leaving the lane unable to emit the follow-up `Updates VERSIONS.md` commit.

### Description

`get_ios_version` now reads `.version` from the local submodule checkout when available, and falls back to fetching it from the GitHub Contents API pinned to the submodule's commit SHA. Mirrors the `get_billing_client_version` pattern, but avoids an extra API call when the submodule is already initialized.

Also backfills the 3.0.1 row in `VERSIONS.md`. The 3.0.2 row from #862 will need to be backfilled separately if it merges before this lands.