### PR TITLE
Fix git ls-tree path in get_ios_version

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -134,7 +134,7 @@ def get_ios_version
   end
 
   require 'base64'
-  submodule_sha = `git ls-tree HEAD upstream/purchases-ios`.split[2]
+  submodule_sha = `git -C .. ls-tree HEAD upstream/purchases-ios`.split[2]
   UI.user_error!("Could not read upstream/purchases-ios submodule commit from the parent tree") if submodule_sha.nil? || submodule_sha.empty?
   response = github_api(
     server_url: 'https://api.github.com',


### PR DESCRIPTION
### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other hybrids

### Motivation

Follow-up to #863. The lane crashed at the new `git ls-tree` guard during the 3.0.2 release, so `VERSIONS.md` is still not being updated automatically.

### Description

Fastlane runs from `fastlane/`, so `git ls-tree HEAD upstream/purchases-ios` was resolving against `fastlane/upstream/purchases-ios` and returning empty. Add `-C ..` so git runs from the repo root.

Made with [Cursor](https://cursor.com)