### PR TITLE
Add Maven consumer link checks to release CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,7 @@ jobs:
       - restore-kotlin-native-compiler-from-cache
       - run:
           name: Build publish artifacts (Maven Local only)
-          command: ./gradlew publishToMavenLocal --no-configuration-cache
+          command: ./gradlew publishToMavenLocal --no-configuration-cache -PskipSigningForMavenLocal=true
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
       - save-maven-local-artifacts-to-workspace
@@ -444,7 +444,6 @@ jobs:
     executor: xcode26-consumer
     steps:
       - checkout
-      - checkout-submodule
       - attach-maven-local-artifacts-from-workspace
       - run:
           name: Verify Maven Local SDK artifacts are present

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,12 +547,6 @@ workflows:
           # This would benefit from the incremental build output of build-libraries-android
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
-      # TEMP: validate Maven consumer checks on PRs before moving them to release-only.
-      - validate-publish
-      - validate-android-consumer-link:
-          requires: [validate-publish]
-      - validate-ios-consumer-link:
-          requires: [validate-publish]
 
   on-main-branch:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,12 +546,6 @@ workflows:
           # This would benefit from the incremental build output of build-libraries-android
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
-      # TEMP: validate Maven consumer checks on PRs before moving them to release-only.
-      - validate-publish
-      - validate-android-consumer-link:
-          requires: [validate-publish]
-      - validate-ios-consumer-link:
-          requires: [validate-publish]
 
   on-main-branch:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,6 +553,12 @@ workflows:
           # This would benefit from the incremental build output of build-libraries-android
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
+      # TEMP: validate Maven consumer checks on PRs before moving them to release-only.
+      - validate-publish
+      - validate-android-consumer-link:
+          requires: [validate-publish]
+      - validate-ios-consumer-link:
+          requires: [validate-publish]
 
   on-main-branch:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ executors:
     resource_class: large
     environment:
       ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts: "true"
+      ORG_GRADLE_PROJECT_installationTestAppOnlyBuild: "true"
   jdk17:
     docker:
       - image: cimg/openjdk:17.0
@@ -181,6 +182,7 @@ executors:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts: "true"
+      ORG_GRADLE_PROJECT_installationTestAppOnlyBuild: "true"
 
 jobs:
   prepare-next-snapshot-version:
@@ -435,7 +437,7 @@ jobs:
       - run:
           name: Build Android installation test app against Maven Local artifacts
           command: |
-            printf '\nusePublishedMavenLocalArtifacts=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
+            printf '\nusePublishedMavenLocalArtifacts=true\ninstallationTestAppOnlyBuild=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
             ./gradlew :installationTestApp:assembleDebug
       - save-gradle-user-home-directory-to-cache
 
@@ -444,7 +446,6 @@ jobs:
     executor: xcode26-consumer
     steps:
       - checkout
-      - checkout-submodule
       - attach-maven-local-artifacts-from-workspace
       - run:
           name: Verify Maven Local SDK artifacts are present
@@ -458,7 +459,7 @@ jobs:
       - run:
           name: Build iOS installation test app against Maven Local artifacts
           command: |
-            printf '\nusePublishedMavenLocalArtifacts=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
+            printf '\nusePublishedMavenLocalArtifacts=true\ninstallationTestAppOnlyBuild=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
             xcodebuild \
               -project installationTestApp/iosApp/iosApp.xcodeproj \
               -scheme iosApp \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,13 +173,6 @@ executors:
       # Avoid waiting for Homebrew to auto update existing packages, as everything we care about is
       # freshly installed.
       HOMEBREW_NO_AUTO_UPDATE: 1
-  # Builds release publish artifacts the way Maven Central consumers receive them (#859).
-  xcode16:
-    macos:
-      xcode: 16.4.0
-    resource_class: m4pro.medium
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
   # Links the installation test app against Maven Local artifacts on a current Xcode 26 image.
   xcode26-consumer:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ executors:
     resource_class: m4pro.medium
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
-  # Links the sample app against Maven Local artifacts on a current Xcode 26 image.
+  # Links the installation test app against Maven Local artifacts on a current Xcode 26 image.
   xcode26-consumer:
     macos:
       xcode: 26.5.0
@@ -408,7 +408,7 @@ jobs:
       - save-maven-local-artifacts-to-workspace
 
   validate-ios-consumer-link:
-    description: "Links the sample app against Maven Local SDK artifacts using Xcode 26.5."
+    description: "Links the installation test app against Maven Local SDK artifacts."
     executor: xcode26-consumer
     steps:
       - checkout
@@ -424,11 +424,11 @@ jobs:
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - run:
-          name: Build iOS sample app against Maven Local artifacts
+          name: Build iOS installation test app against Maven Local artifacts
           command: |
             printf '\nusePublishedMavenLocalArtifacts=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
             xcodebuild \
-              -project iosApp/iosApp.xcodeproj \
+              -project installationTestApp/iosApp/iosApp.xcodeproj \
               -scheme iosApp \
               -configuration Debug \
               -sdk iphonesimulator \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,12 @@ executors:
     docker:
       - image: cimg/android:2024.09.1
     resource_class: large
+  android-consumer:
+    docker:
+      - image: cimg/android:2024.09.1
+    resource_class: large
+    environment:
+      ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts: "true"
   jdk17:
     docker:
       - image: cimg/openjdk:17.0
@@ -407,6 +413,25 @@ jobs:
       - save-kotlin-native-compiler-to-cache
       - save-maven-local-artifacts-to-workspace
 
+  validate-android-consumer-link:
+    description: "Builds the installation test app against Maven Local SDK artifacts."
+    executor: android-consumer
+    steps:
+      - checkout
+      - attach-maven-local-artifacts-from-workspace
+      - run:
+          name: Verify Maven Local SDK artifacts are present
+          command: |
+            test -d ~/.m2/repository/com/revenuecat/purchases/purchases-kmp-core
+            ls ~/.m2/repository/com/revenuecat/purchases
+      - restore-gradle-user-home-directory-from-cache
+      - run:
+          name: Build Android installation test app against Maven Local artifacts
+          command: |
+            printf '\nusePublishedMavenLocalArtifacts=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
+            ./gradlew :installationTestApp:assembleDebug
+      - save-gradle-user-home-directory-to-cache
+
   validate-ios-consumer-link:
     description: "Links the installation test app against Maven Local SDK artifacts."
     executor: xcode26-consumer
@@ -581,6 +606,8 @@ workflows:
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
       - validate-publish
+      - validate-android-consumer-link:
+          requires: [validate-publish]
       - validate-ios-consumer-link:
           requires: [validate-publish]
       - hold:
@@ -595,6 +622,7 @@ workflows:
             - unit-tests-android
             - unit-tests-ios
             - validate-binary-compatibility
+            - validate-android-consumer-link
             - validate-ios-consumer-link
       - revenuecat/tag-current-branch:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,6 +545,12 @@ workflows:
           # This would benefit from the incremental build output of build-libraries-android
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
+      # TEMP: validate Maven consumer checks on PRs before moving them to release-only.
+      - validate-publish
+      - validate-android-consumer-link:
+          requires: [validate-publish]
+      - validate-ios-consumer-link:
+          requires: [validate-publish]
 
   on-main-branch:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,34 @@ commands:
           name: Attach workspace at working directory
           at: ./
 
+  save-maven-local-artifacts-to-workspace:
+    steps:
+      - run:
+          name: Stage Maven Local artifacts for workspace
+          command: |
+            test -d "$HOME/.m2/repository/com/revenuecat/purchases"
+            mkdir -p maven-local-artifacts/com
+            cp -R "$HOME/.m2/repository/com/revenuecat" maven-local-artifacts/com/
+            find maven-local-artifacts/com/revenuecat/purchases -maxdepth 3 -type d
+      - persist_to_workspace:
+          name: Save Maven Local artifacts to workspace
+          root: ./
+          paths:
+            - maven-local-artifacts/com/revenuecat
+
+  attach-maven-local-artifacts-from-workspace:
+    steps:
+      - attach_workspace:
+          name: Attach Maven Local artifacts from workspace
+          at: ./
+      - run:
+          name: Restore Maven Local artifacts from workspace
+          command: |
+            test -d maven-local-artifacts/com/revenuecat/purchases
+            mkdir -p "$HOME/.m2/repository/com/revenuecat"
+            cp -R maven-local-artifacts/com/revenuecat/purchases "$HOME/.m2/repository/com/revenuecat/"
+            find "$HOME/.m2/repository/com/revenuecat/purchases" -maxdepth 3 -type d
+
   checkout-submodule:
     description: "Checks out a git submodule."
     parameters:
@@ -125,6 +153,21 @@ executors:
       # Avoid waiting for Homebrew to auto update existing packages, as everything we care about is
       # freshly installed.
       HOMEBREW_NO_AUTO_UPDATE: 1
+  # Builds release publish artifacts the way Maven Central consumers receive them (#859).
+  xcode16:
+    macos:
+      xcode: 16.4.0
+    resource_class: m4pro.medium
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+  # Links the sample app against Maven Local artifacts on a current Xcode 26 image.
+  xcode26-consumer:
+    macos:
+      xcode: 26.5.0
+    resource_class: m4pro.medium
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts: "true"
 
 jobs:
   prepare-next-snapshot-version:
@@ -348,6 +391,53 @@ jobs:
       - save-gradle-user-home-directory-to-cache
       - save-incremental-gradle-build-to-workspace
 
+  validate-publish:
+    description: "Builds release publish artifacts locally without uploading to Maven Central."
+    executor: xcode16
+    steps:
+      - checkout
+      - checkout-submodule
+      - install-android-sdk-on-macos
+      - restore-gradle-user-home-directory-from-cache
+      - restore-kotlin-native-compiler-from-cache
+      - run:
+          name: Build publish artifacts (Maven Local only)
+          command: ./gradlew publishToMavenLocal --no-configuration-cache
+      - save-gradle-user-home-directory-to-cache
+      - save-kotlin-native-compiler-to-cache
+      - save-maven-local-artifacts-to-workspace
+
+  validate-ios-consumer-link:
+    description: "Links the sample app against Maven Local SDK artifacts using Xcode 26.5."
+    executor: xcode26-consumer
+    steps:
+      - checkout
+      - checkout-submodule
+      - attach-maven-local-artifacts-from-workspace
+      - run:
+          name: Verify Maven Local SDK artifacts are present
+          command: |
+            test -d ~/.m2/repository/com/revenuecat/purchases/purchases-kmp-core
+            ls ~/.m2/repository/com/revenuecat/purchases
+      - restore-gradle-user-home-directory-from-cache
+      - restore-kotlin-native-compiler-from-cache
+      - revenuecat/install-gem-mac-dependencies:
+          cache-version: v1
+      - run:
+          name: Build iOS sample app against Maven Local artifacts
+          command: |
+            printf '\nusePublishedMavenLocalArtifacts=true\norg.gradle.configuration-cache=false\n' >> gradle.properties
+            xcodebuild \
+              -project iosApp/iosApp.xcodeproj \
+              -scheme iosApp \
+              -configuration Debug \
+              -sdk iphonesimulator \
+              -arch arm64 \
+              ONLY_ACTIVE_ARCH=YES \
+              build
+      - save-gradle-user-home-directory-to-cache
+      - save-kotlin-native-compiler-to-cache
+
   publish:
     description: "Publishes the SDK, either a SNAPSHOT or release version."
     executor: xcode26
@@ -490,6 +580,9 @@ workflows:
           # This would benefit from the incremental build output of build-libraries-android
           # too, but merging 2 workspaces is not possible.
           requires: [build-libraries-ios]
+      - validate-publish
+      - validate-ios-consumer-link:
+          requires: [validate-publish]
       - hold:
           type: approval
           requires:
@@ -502,6 +595,7 @@ workflows:
             - unit-tests-android
             - unit-tests-ios
             - validate-binary-compatibility
+            - validate-ios-consumer-link
       - revenuecat/tag-current-branch:
           requires:
             - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,6 +444,7 @@ jobs:
     executor: xcode26-consumer
     steps:
       - checkout
+      - checkout-submodule
       - attach-maven-local-artifacts-from-workspace
       - run:
           name: Verify Maven Local SDK artifacts are present

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,10 +27,10 @@ allprojects {
     plugins.withType<MavenPublishPlugin> {
         configure<MavenPublishBaseExtension> {
             publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-            val publishingToMavenLocal = gradle.startParameter.taskNames.any {
-                it.contains("publishToMavenLocal", ignoreCase = true)
-            }
-            if (!publishingToMavenLocal) {
+            val skipSigningForMavenLocal = providers.gradleProperty("skipSigningForMavenLocal")
+                .map { it.equals("true", ignoreCase = true) }
+                .orElse(false)
+            if (!skipSigningForMavenLocal.get()) {
                 signAllPublications()
             }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ allprojects {
 }
 
 apiValidation {
-    ignoredProjects.addAll(listOf("apiTester", "composeApp", "MaestroTestApp", "mappings"))
+    ignoredProjects.addAll(listOf("apiTester", "composeApp", "MaestroTestApp", "installationTestApp", "mappings"))
 
     @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
     klib {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,12 @@ allprojects {
     plugins.withType<MavenPublishPlugin> {
         configure<MavenPublishBaseExtension> {
             publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-            signAllPublications()
+            val publishingToMavenLocal = gradle.startParameter.taskNames.any {
+                it.contains("publishToMavenLocal", ignoreCase = true)
+            }
+            if (!publishingToMavenLocal) {
+                signAllPublications()
+            }
 
             // We override the artifact ID of :revenuecatui for consistency with the other SDKs. We
             // could not name our Gradle module :ui, because this somehow conflicts with compose.ui

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,8 +102,16 @@ allprojects {
     }
 }
 
+val installationTestAppOnlyBuild = providers.gradleProperty("installationTestAppOnlyBuild")
+    .map { it.equals("true", ignoreCase = true) }
+    .orElse(false)
+
 apiValidation {
-    ignoredProjects.addAll(listOf("apiTester", "composeApp", "MaestroTestApp", "installationTestApp", "mappings"))
+    if (installationTestAppOnlyBuild.get()) {
+        ignoredProjects.addAll(listOf("installationTestApp"))
+    } else {
+        ignoredProjects.addAll(listOf("apiTester", "composeApp", "MaestroTestApp", "installationTestApp", "mappings"))
+    }
 
     @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
     klib {
@@ -111,39 +119,41 @@ apiValidation {
     }
 }
 
-dependencies {
-    dokkatoo(projects.core)
-    dokkatoo(projects.either)
-    dokkatoo(projects.models)
-    dokkatoo(projects.result)
-    dokkatoo(projects.revenuecatui)
-}
+if (!installationTestAppOnlyBuild.get()) {
+    dependencies {
+        dokkatoo(project(":core"))
+        dokkatoo(project(":either"))
+        dokkatoo(project(":models"))
+        dokkatoo(project(":result"))
+        dokkatoo(project(":revenuecatui"))
+    }
 
-moduleGraphConfig {
-    fun Dependency.readmePath() = "./$name/README.md"
-    fun Dependency.heading() = "## :${name} module dependency graph"
-    val topToBottom = Orientation.TOP_TO_BOTTOM
-    // Intentional root for all modules, so we always show the entire graph.
-    val rootModuleRegex = ".*revenuecatui.*"
+    moduleGraphConfig {
+        fun Project.readmePath() = "./$name/README.md"
+        fun Project.heading() = "## :${name} module dependency graph"
+        val topToBottom = Orientation.TOP_TO_BOTTOM
+        // Intentional root for all modules, so we always show the entire graph.
+        val rootModuleRegex = ".*revenuecatui.*"
 
-    listOf(
-        projects.core,
-        projects.mappings,
-        projects.models,
-        projects.revenuecatui,
-    ).forEach { project ->
-        // All graphs are equal, but we need to specify 1 main graph. So :core it is.
-        if (project == projects.core) {
-            readmePath.set(project.readmePath())
-            heading = project.heading()
-            orientation.set(topToBottom)
-            rootModulesRegex.set(rootModuleRegex)
-        } else graph(
-            readmePath = project.readmePath(),
-            heading = project.heading(),
-        ) {
-            orientation = topToBottom
-            rootModulesRegex = rootModuleRegex
+        listOf(
+            project(":core"),
+            project(":mappings"),
+            project(":models"),
+            project(":revenuecatui"),
+        ).forEach { moduleProject ->
+            // All graphs are equal, but we need to specify 1 main graph. So :core it is.
+            if (moduleProject == project(":core")) {
+                readmePath.set(moduleProject.readmePath())
+                heading = moduleProject.heading()
+                orientation.set(topToBottom)
+                rootModulesRegex.set(rootModuleRegex)
+            } else graph(
+                readmePath = moduleProject.readmePath(),
+                heading = moduleProject.heading(),
+            ) {
+                orientation = topToBottom
+                rootModulesRegex = rootModuleRegex
+            }
         }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -9,10 +9,6 @@ plugins {
     alias(libs.plugins.codingfeline.buildkonfig)
 }
 
-val usePublishedMavenLocalArtifacts = providers.gradleProperty("usePublishedMavenLocalArtifacts")
-    .map { it.equals("true", ignoreCase = true) }
-    .orElse(false)
-
 kotlin {
     androidTarget {
         compilations.all {
@@ -49,18 +45,10 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
-            if (usePublishedMavenLocalArtifacts.get()) {
-                val version = libs.versions.revenuecat.kmp.get()
-                implementation("com.revenuecat.purchases:purchases-kmp-core:$version")
-                implementation("com.revenuecat.purchases:purchases-kmp-result:$version")
-                implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
-                implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
-            } else {
-                implementation(projects.core)
-                implementation(projects.result)
-                implementation(projects.either)
-                implementation(projects.revenuecatui)
-            }
+            implementation(projects.core)
+            implementation(projects.result)
+            implementation(projects.either)
+            implementation(projects.revenuecatui)
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
     alias(libs.plugins.codingfeline.buildkonfig)
 }
 
+val usePublishedMavenLocalArtifacts = providers.gradleProperty("usePublishedMavenLocalArtifacts")
+    .map { it.equals("true", ignoreCase = true) }
+    .orElse(false)
+
 kotlin {
     androidTarget {
         compilations.all {
@@ -45,10 +49,18 @@ kotlin {
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
-            implementation(projects.core)
-            implementation(projects.result)
-            implementation(projects.either)
-            implementation(projects.revenuecatui)
+            if (usePublishedMavenLocalArtifacts.get()) {
+                val version = libs.versions.revenuecat.kmp.get()
+                implementation("com.revenuecat.purchases:purchases-kmp-core:$version")
+                implementation("com.revenuecat.purchases:purchases-kmp-result:$version")
+                implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
+                implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
+            } else {
+                implementation(projects.core)
+                implementation(projects.result)
+                implementation(projects.either)
+                implementation(projects.revenuecatui)
+            }
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)

--- a/installationTestApp/README.md
+++ b/installationTestApp/README.md
@@ -2,7 +2,7 @@
 
 Minimal Android and iOS consumer app used by release CI to verify Maven-published SDK artifacts compile and link like external integrators.
 
-Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template. Uses project dependencies locally; consumer CI resolves from Maven Local via `-PusePublishedMavenLocalArtifacts=true`.
+Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template. Uses project dependencies locally; consumer CI resolves from Maven Local via `-PusePublishedMavenLocalArtifacts=true` and limits the Gradle build to this module via `-PinstallationTestAppOnlyBuild=true`.
 
 ## CI usage
 
@@ -14,7 +14,7 @@ Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared
 
 ```bash
 ./gradlew publishToMavenLocal
-printf '\nusePublishedMavenLocalArtifacts=true\n' >> gradle.properties
+printf '\nusePublishedMavenLocalArtifacts=true\ninstallationTestAppOnlyBuild=true\n' >> gradle.properties
 ./gradlew :installationTestApp:assembleDebug
 xcodebuild -project installationTestApp/iosApp/iosApp.xcodeproj -scheme iosApp -sdk iphonesimulator -arch arm64 build
 ```

--- a/installationTestApp/README.md
+++ b/installationTestApp/README.md
@@ -2,7 +2,7 @@
 
 Minimal Android and iOS consumer app used by release CI to verify Maven-published SDK artifacts compile and link like external integrators.
 
-Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template, then wired to resolve `purchases-kmp` from Maven Local. Kotlin is pinned to the minimum supported version via the root version catalog (`2.3.20`).
+Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template. Uses project dependencies locally; consumer CI resolves from Maven Local via `-PusePublishedMavenLocalArtifacts=true`.
 
 ## CI usage
 

--- a/installationTestApp/README.md
+++ b/installationTestApp/README.md
@@ -1,18 +1,20 @@
 # Installation test app
 
-Minimal iOS consumer app used by release CI to verify Maven-published SDK artifacts link on current Xcode versions.
+Minimal Android and iOS consumer app used by release CI to verify Maven-published SDK artifacts compile and link like external integrators.
 
-Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template, then trimmed to iOS-only and wired to resolve `purchases-kmp` from Maven Local. Kotlin is pinned to the minimum supported version via the root version catalog (`2.3.20`).
+Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template, then wired to resolve `purchases-kmp` from Maven Local. Kotlin is pinned to the minimum supported version via the root version catalog (`2.3.20`).
 
 ## CI usage
 
 1. `validate-publish` runs `publishToMavenLocal` on Xcode 16.4.
-2. `validate-ios-consumer-link` restores those artifacts and builds this app on Xcode 26.5.
+2. `validate-android-consumer-link` restores those artifacts and assembles the Android app.
+3. `validate-ios-consumer-link` restores those artifacts and builds the iOS app.
 
 ## Local usage
 
 ```bash
 ./gradlew publishToMavenLocal
 printf '\nusePublishedMavenLocalArtifacts=true\n' >> gradle.properties
+./gradlew :installationTestApp:assembleDebug
 xcodebuild -project installationTestApp/iosApp/iosApp.xcodeproj -scheme iosApp -sdk iphonesimulator -arch arm64 build
 ```

--- a/installationTestApp/README.md
+++ b/installationTestApp/README.md
@@ -1,0 +1,18 @@
+# Installation test app
+
+Minimal iOS consumer app used by release CI to verify Maven-published SDK artifacts link on current Xcode versions.
+
+Generated from the [Kotlin Multiplatform Wizard](https://kmp.new/) mobile-shared template, then trimmed to iOS-only and wired to resolve `purchases-kmp` from Maven Local. Kotlin is pinned to the minimum supported version via the root version catalog (`2.3.20`).
+
+## CI usage
+
+1. `validate-publish` runs `publishToMavenLocal` on Xcode 16.4.
+2. `validate-ios-consumer-link` restores those artifacts and builds this app on Xcode 26.5.
+
+## Local usage
+
+```bash
+./gradlew publishToMavenLocal
+printf '\nusePublishedMavenLocalArtifacts=true\n' >> gradle.properties
+xcodebuild -project installationTestApp/iosApp/iosApp.xcodeproj -scheme iosApp -sdk iphonesimulator -arch arm64 build
+```

--- a/installationTestApp/build.gradle.kts
+++ b/installationTestApp/build.gradle.kts
@@ -1,12 +1,15 @@
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
 }
 
 // Minimal consumer app for release CI. Uses the minimum supported Kotlin version from the root
-// catalog and Maven Local SDK artifacts (see validate-ios-consumer-link in .circleci/config.yml).
+// catalog and Maven Local SDK artifacts (see validate-*-consumer-link in .circleci/config.yml).
 kotlin {
+    androidTarget()
+
     listOf(
         iosArm64(),
         iosSimulatorArm64(),
@@ -37,5 +40,27 @@ kotlin {
             implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
             implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
         }
+        androidMain.dependencies {
+            implementation(libs.androidx.activity.compose)
+        }
+    }
+}
+
+android {
+    namespace = "com.revenuecat.purchases.kmp.installationtest"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+
+    defaultConfig {
+        applicationId = "com.revenuecat.purchases.kmp.installationtest"
+        minSdk = 24 // revenuecatui requires minSdk 24
+        targetSdk = libs.versions.android.targetSdk.get().toInt()
+        versionCode = 1
+        versionName = "1.0"
+    }
+    compileOptions {
+        sourceCompatibility(libs.versions.java.get())
+        targetCompatibility(libs.versions.java.get())
     }
 }

--- a/installationTestApp/build.gradle.kts
+++ b/installationTestApp/build.gradle.kts
@@ -45,10 +45,10 @@ kotlin {
                 implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
                 implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
             } else {
-                implementation(projects.core)
-                implementation(projects.result)
-                implementation(projects.either)
-                implementation(projects.revenuecatui)
+                implementation(project(":core"))
+                implementation(project(":result"))
+                implementation(project(":either"))
+                implementation(project(":revenuecatui"))
             }
         }
         androidMain.dependencies {

--- a/installationTestApp/build.gradle.kts
+++ b/installationTestApp/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.jetbrains.compose)
+    alias(libs.plugins.compose.compiler)
+}
+
+// Minimal consumer app for release CI. Uses the minimum supported Kotlin version from the root
+// catalog and Maven Local SDK artifacts (see validate-ios-consumer-link in .circleci/config.yml).
+kotlin {
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    ).forEach { iosTarget ->
+        iosTarget.binaries.framework {
+            baseName = "Shared"
+            isStatic = true
+        }
+    }
+
+    sourceSets {
+        all {
+            languageSettings.apply {
+                if (name.lowercase().startsWith("ios")) {
+                    optIn("kotlinx.cinterop.ExperimentalForeignApi")
+                }
+            }
+        }
+        commonMain.dependencies {
+            implementation(compose.runtime)
+            implementation(compose.foundation)
+            implementation(compose.material)
+            implementation(compose.ui)
+
+            val version = libs.versions.revenuecat.kmp.get()
+            implementation("com.revenuecat.purchases:purchases-kmp-core:$version")
+            implementation("com.revenuecat.purchases:purchases-kmp-result:$version")
+            implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
+            implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
+        }
+    }
+}

--- a/installationTestApp/build.gradle.kts
+++ b/installationTestApp/build.gradle.kts
@@ -5,8 +5,12 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
+val usePublishedMavenLocalArtifacts = providers.gradleProperty("usePublishedMavenLocalArtifacts")
+    .map { it.equals("true", ignoreCase = true) }
+    .orElse(false)
+
 // Minimal consumer app for release CI. Uses the minimum supported Kotlin version from the root
-// catalog and Maven Local SDK artifacts (see validate-*-consumer-link in .circleci/config.yml).
+// catalog. Resolves SDK from project dependencies locally; Maven Local in consumer CI jobs.
 kotlin {
     androidTarget()
 
@@ -34,11 +38,18 @@ kotlin {
             implementation(compose.material)
             implementation(compose.ui)
 
-            val version = libs.versions.revenuecat.kmp.get()
-            implementation("com.revenuecat.purchases:purchases-kmp-core:$version")
-            implementation("com.revenuecat.purchases:purchases-kmp-result:$version")
-            implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
-            implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
+            if (usePublishedMavenLocalArtifacts.get()) {
+                val version = libs.versions.revenuecat.kmp.get()
+                implementation("com.revenuecat.purchases:purchases-kmp-core:$version")
+                implementation("com.revenuecat.purchases:purchases-kmp-result:$version")
+                implementation("com.revenuecat.purchases:purchases-kmp-either:$version")
+                implementation("com.revenuecat.purchases:purchases-kmp-ui:$version")
+            } else {
+                implementation(projects.core)
+                implementation(projects.result)
+                implementation(projects.either)
+                implementation(projects.revenuecatui)
+            }
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)

--- a/installationTestApp/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/installationTestApp/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -1,0 +1,359 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C100000100000001 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000100000001 /* iOSApp.swift */; };
+		C100000200000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C200000200000002 /* ContentView.swift */; };
+		C100000300000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C200000300000003 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		C200000100000001 /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		C200000200000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C200000300000003 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C200000400000004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C200000500000005 /* InstallationTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InstallationTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C300000100000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C400000100000001 = {
+			isa = PBXGroup;
+			children = (
+				C400000300000003 /* iosApp */,
+				C400000200000002 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C400000200000002 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C200000500000005 /* InstallationTestApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C400000300000003 /* iosApp */ = {
+			isa = PBXGroup;
+			children = (
+				C200000100000001 /* iOSApp.swift */,
+				C200000200000002 /* ContentView.swift */,
+				C200000300000003 /* Assets.xcassets */,
+				C200000400000004 /* Info.plist */,
+			);
+			path = iosApp;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C500000100000001 /* iosApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C700000300000003 /* Build configuration list for PBXNativeTarget "iosApp" */;
+			buildPhases = (
+				C800000100000001 /* Compile Kotlin Framework */,
+				C600000100000001 /* Sources */,
+				C300000100000001 /* Frameworks */,
+				C600000200000002 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iosApp;
+			productName = iosApp;
+			productReference = C200000500000005 /* InstallationTestApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C900000100000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					C500000100000001 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = C700000100000001 /* Build configuration list for PBXProject "iosApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C400000100000001;
+			productRefGroup = C400000200000002 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C500000100000001 /* iosApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C600000200000002 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C100000300000003 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		C800000100000001 /* Compile Kotlin Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Compile Kotlin Framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\nexport ARCHS=arm64\nexport ONLY_ACTIVE_ARCH=YES\nexport EXCLUDED_ARCHS=x86_64\nexport ENABLE_DEBUG_DYLIB=NO\ncd \"$SRCROOT/../..\"\n./gradlew :installationTestApp:embedAndSignAppleFrameworkForXcode --no-parallel --max-workers=1 --no-daemon --no-configuration-cache\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C600000100000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C100000100000001 /* iOSApp.swift in Sources */,
+				C100000200000002 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		D100000100000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D100000200000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D200000100000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					Shared,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.purchases.kmp.installationtest;
+				PRODUCT_NAME = InstallationTestApp;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D200000200000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_PREVIEWS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					Shared,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.purchases.kmp.installationtest;
+				PRODUCT_NAME = InstallationTestApp;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C700000100000001 /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D100000100000001 /* Debug */,
+				D100000200000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C700000300000003 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D200000100000001 /* Debug */,
+				D200000200000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C900000100000001 /* Project object */;
+}

--- a/installationTestApp/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/installationTestApp/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C500000100000001"
+               BuildableName = "InstallationTestApp.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C500000100000001"
+            BuildableName = "InstallationTestApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C500000100000001"
+            BuildableName = "InstallationTestApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/installationTestApp/iosApp/iosApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/installationTestApp/iosApp/iosApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/installationTestApp/iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/installationTestApp/iosApp/iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/installationTestApp/iosApp/iosApp/Assets.xcassets/Contents.json
+++ b/installationTestApp/iosApp/iosApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/installationTestApp/iosApp/iosApp/ContentView.swift
+++ b/installationTestApp/iosApp/iosApp/ContentView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import Shared
+
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        MainViewControllerKt.MainViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+struct ContentView: View {
+    var body: some View {
+        ComposeView()
+            .ignoresSafeArea(.keyboard)
+    }
+}

--- a/installationTestApp/iosApp/iosApp/Info.plist
+++ b/installationTestApp/iosApp/iosApp/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/installationTestApp/iosApp/iosApp/iOSApp.swift
+++ b/installationTestApp/iosApp/iosApp/iOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct InstallationTestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/installationTestApp/src/androidMain/AndroidManifest.xml
+++ b/installationTestApp/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="InstallationTestApp"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/installationTestApp/src/androidMain/kotlin/com/revenuecat/purchases/kmp/installationtest/MainActivity.kt
+++ b/installationTestApp/src/androidMain/kotlin/com/revenuecat/purchases/kmp/installationtest/MainActivity.kt
@@ -1,0 +1,17 @@
+package com.revenuecat.purchases.kmp.installationtest
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.revenuecat.purchases.kmp.Purchases
+import com.revenuecat.purchases.kmp.PurchasesConfiguration
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Purchases.configure(PurchasesConfiguration(PLACEHOLDER_API_KEY))
+        setContent {
+            App()
+        }
+    }
+}

--- a/installationTestApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/installationtest/App.kt
+++ b/installationTestApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/installationtest/App.kt
@@ -1,7 +1,6 @@
 package com.revenuecat.purchases.kmp.installationtest
 
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import com.revenuecat.purchases.kmp.ui.revenuecatui.Paywall
 import com.revenuecat.purchases.kmp.ui.revenuecatui.PaywallOptions
@@ -9,10 +8,8 @@ import com.revenuecat.purchases.kmp.ui.revenuecatui.PaywallOptions
 @Composable
 fun App() {
     MaterialTheme {
-        // Paywall pulls in RevenueCatUI static Swift artifacts for the link check (#859).
         Paywall(
             PaywallOptions(dismissRequest = {}) {},
         )
-        Text("Installation test")
     }
 }

--- a/installationTestApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/installationtest/App.kt
+++ b/installationTestApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/installationtest/App.kt
@@ -1,0 +1,18 @@
+package com.revenuecat.purchases.kmp.installationtest
+
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.kmp.ui.revenuecatui.Paywall
+import com.revenuecat.purchases.kmp.ui.revenuecatui.PaywallOptions
+
+@Composable
+fun App() {
+    MaterialTheme {
+        // Paywall pulls in RevenueCatUI static Swift artifacts for the link check (#859).
+        Paywall(
+            PaywallOptions(dismissRequest = {}) {},
+        )
+        Text("Installation test")
+    }
+}

--- a/installationTestApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/installationtest/InstallationTestConstants.kt
+++ b/installationTestApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/installationtest/InstallationTestConstants.kt
@@ -1,0 +1,3 @@
+package com.revenuecat.purchases.kmp.installationtest
+
+internal const val PLACEHOLDER_API_KEY = "installation_test_api_key"

--- a/installationTestApp/src/iosMain/kotlin/com/revenuecat/purchases/kmp/installationtest/MainViewController.kt
+++ b/installationTestApp/src/iosMain/kotlin/com/revenuecat/purchases/kmp/installationtest/MainViewController.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.kmp.installationtest
+
+import androidx.compose.ui.window.ComposeUIViewController
+import com.revenuecat.purchases.kmp.Purchases
+import com.revenuecat.purchases.kmp.PurchasesConfiguration
+
+private const val PLACEHOLDER_API_KEY = "installation_test_api_key"
+
+@Suppress("unused", "FunctionName")
+fun MainViewController(): platform.UIKit.UIViewController {
+    Purchases.configure(PurchasesConfiguration(PLACEHOLDER_API_KEY))
+    return ComposeUIViewController { App() }
+}

--- a/installationTestApp/src/iosMain/kotlin/com/revenuecat/purchases/kmp/installationtest/MainViewController.kt
+++ b/installationTestApp/src/iosMain/kotlin/com/revenuecat/purchases/kmp/installationtest/MainViewController.kt
@@ -4,8 +4,6 @@ import androidx.compose.ui.window.ComposeUIViewController
 import com.revenuecat.purchases.kmp.Purchases
 import com.revenuecat.purchases.kmp.PurchasesConfiguration
 
-private const val PLACEHOLDER_API_KEY = "installation_test_api_key"
-
 @Suppress("unused", "FunctionName")
 fun MainViewController(): platform.UIKit.UIViewController {
     Purchases.configure(PurchasesConfiguration(PLACEHOLDER_API_KEY))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,8 +12,14 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        val gradleProperties = java.util.Properties()
+        val gradlePropertiesFile = File(settingsDir, "gradle.properties")
+        if (gradlePropertiesFile.exists()) {
+            gradlePropertiesFile.inputStream().use { gradleProperties.load(it) }
+        }
         val usePublishedMavenLocalArtifacts =
-            startParameter.projectProperties["usePublishedMavenLocalArtifacts"] == "true" ||
+            gradleProperties.getProperty("usePublishedMavenLocalArtifacts") == "true" ||
+                startParameter.projectProperties["usePublishedMavenLocalArtifacts"] == "true" ||
                 System.getenv("ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts") == "true"
         if (usePublishedMavenLocalArtifacts) {
             mavenLocal()
@@ -35,3 +41,4 @@ include(":models")
 include(":result")
 include(":revenuecatui")
 include(":e2e-tests:MaestroTestApp")
+include(":installationTestApp")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,12 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
+        val usePublishedMavenLocalArtifacts =
+            startParameter.projectProperties["usePublishedMavenLocalArtifacts"] == "true" ||
+                System.getenv("ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts") == "true"
+        if (usePublishedMavenLocalArtifacts) {
+            mavenLocal()
+        }
         google()
         mavenCentral()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,4 @@ include(":models")
 include(":result")
 include(":revenuecatui")
 include(":e2e-tests:MaestroTestApp")
-if (usePublishedMavenLocalArtifacts()) {
-    include(":installationTestApp")
-}
+include(":installationTestApp")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,27 +20,37 @@ dependencyResolutionManagement {
     }
 }
 
-fun usePublishedMavenLocalArtifacts(): Boolean {
+fun gradlePropertyEnabled(name: String): Boolean {
     val gradleProperties = java.util.Properties()
     val gradlePropertiesFile = File(settingsDir, "gradle.properties")
     if (gradlePropertiesFile.exists()) {
         gradlePropertiesFile.inputStream().use { gradleProperties.load(it) }
     }
-    return gradleProperties.getProperty("usePublishedMavenLocalArtifacts") == "true" ||
-        startParameter.projectProperties["usePublishedMavenLocalArtifacts"] == "true" ||
-        System.getenv("ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts") == "true"
+    return gradleProperties.getProperty(name) == "true" ||
+        startParameter.projectProperties[name] == "true" ||
+        System.getenv("ORG_GRADLE_PROJECT_$name") == "true"
 }
 
+fun usePublishedMavenLocalArtifacts(): Boolean =
+    gradlePropertyEnabled("usePublishedMavenLocalArtifacts")
+
+fun installationTestAppOnlyBuild(): Boolean =
+    gradlePropertyEnabled("installationTestAppOnlyBuild")
+
 rootProject.name = "purchases-kmp"
-include(":apiTester")
-include(":composeApp")
-include(":core")
-include(":either")
-include(":kn-core")
-include(":kn-ui")
-include(":mappings")
-include(":models")
-include(":result")
-include(":revenuecatui")
-include(":e2e-tests:MaestroTestApp")
-include(":installationTestApp")
+if (installationTestAppOnlyBuild()) {
+    include(":installationTestApp")
+} else {
+    include(":apiTester")
+    include(":composeApp")
+    include(":core")
+    include(":either")
+    include(":kn-core")
+    include(":kn-ui")
+    include(":mappings")
+    include(":models")
+    include(":result")
+    include(":revenuecatui")
+    include(":e2e-tests:MaestroTestApp")
+    include(":installationTestApp")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,21 +12,23 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
-        val gradleProperties = java.util.Properties()
-        val gradlePropertiesFile = File(settingsDir, "gradle.properties")
-        if (gradlePropertiesFile.exists()) {
-            gradlePropertiesFile.inputStream().use { gradleProperties.load(it) }
-        }
-        val usePublishedMavenLocalArtifacts =
-            gradleProperties.getProperty("usePublishedMavenLocalArtifacts") == "true" ||
-                startParameter.projectProperties["usePublishedMavenLocalArtifacts"] == "true" ||
-                System.getenv("ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts") == "true"
-        if (usePublishedMavenLocalArtifacts) {
+        if (usePublishedMavenLocalArtifacts()) {
             mavenLocal()
         }
         google()
         mavenCentral()
     }
+}
+
+fun usePublishedMavenLocalArtifacts(): Boolean {
+    val gradleProperties = java.util.Properties()
+    val gradlePropertiesFile = File(settingsDir, "gradle.properties")
+    if (gradlePropertiesFile.exists()) {
+        gradlePropertiesFile.inputStream().use { gradleProperties.load(it) }
+    }
+    return gradleProperties.getProperty("usePublishedMavenLocalArtifacts") == "true" ||
+        startParameter.projectProperties["usePublishedMavenLocalArtifacts"] == "true" ||
+        System.getenv("ORG_GRADLE_PROJECT_usePublishedMavenLocalArtifacts") == "true"
 }
 
 rootProject.name = "purchases-kmp"
@@ -41,4 +43,6 @@ include(":models")
 include(":result")
 include(":revenuecatui")
 include(":e2e-tests:MaestroTestApp")
-include(":installationTestApp")
+if (usePublishedMavenLocalArtifacts()) {
+    include(":installationTestApp")
+}


### PR DESCRIPTION
### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other
  hybrids

### Motivation

Follow-up to #872. Guards against #859 by validating Maven publish output and consumer linking before tagging a release.

### Description

- Release-only publish + Android/iOS consumer link jobs; `installationTestApp` uses Maven Local in those jobs, project deps otherwise
- Both consumer jobs gate the release hold
- Verified: [successful CI run](https://app.circleci.com/pipelines/gh/RevenueCat/purchases-kmp/3226/workflows/d8c1800c-eea0-40e3-944b-32cb1227c5b2)