### PR TITLE
Handle unconfigured Purchases in Android Paywall

### DIFF
--- a/revenuecatui/src/androidMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/Paywall.kt
+++ b/revenuecatui/src/androidMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/Paywall.kt
@@ -1,9 +1,28 @@
 package com.revenuecat.purchases.kmp.ui.revenuecatui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.revenuecat.purchases.kmp.Purchases
+import com.revenuecat.purchases.kmp.models.PurchasesError
+import com.revenuecat.purchases.kmp.models.PurchasesErrorCode
 import com.revenuecat.purchases.ui.revenuecatui.ExperimentalPreviewRevenueCatUIPurchasesAPI
 import com.revenuecat.purchases.ui.revenuecatui.Paywall as RcPaywall
 
 @Composable
-public actual fun Paywall(options: PaywallOptions): Unit =
+public actual fun Paywall(options: PaywallOptions): Unit {
+    if (!Purchases.isConfigured) {
+        LaunchedEffect(options) {
+            options.listener?.onPurchaseError(
+                PurchasesError(
+                    code = PurchasesErrorCode.ConfigurationError,
+                    underlyingErrorMessage = "Purchases is not configured. " +
+                        "Call Purchases.configure(...) before showing Paywall."
+                )
+            )
+            options.dismissRequest()
+        }
+        return
+    }
+
     RcPaywall(options.toAndroidPaywallOptions())
+}


### PR DESCRIPTION
## Summary
- add a guard in Android Paywall for Purchases.isConfigured
- if not configured, report a ConfigurationError through the existing listener
- call dismissRequest() and return early instead of crashing

## Why
A crash has been reported when paywall is shown before Purchases.configure(...) has finished or run. This keeps behavior safe and gives host apps a recoverable signal.

## Notes
- scope is limited to Android Paywall entry in revenuecatui
- no public API changes

Fixes #360