### PR TITLE
Replace negative lookahead in CircleCI `when: matches:` condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,16 @@
 aliases:
-  # Uses the same regex as release-tags-job
+  # Matches the same tags as release-tags-job, but without lookaheads,
+  # which are unsupported in `when: matches:` conditions:
+  # https://circleci.com/changelog/breaking-change-regex-engine-update-for-config-compilation/
   release-tags-workflow: &release-tags-workflow
     when:
       and:
-        - matches: { pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+(?!.*-SNAPSHOT).*$", value: << pipeline.git.tag >> }
+        - matches: { pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+.*$", value: << pipeline.git.tag >> }
+        - not:
+            matches: { pattern: ".*-SNAPSHOT.*", value: << pipeline.git.tag >> }
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-  # Uses the same regex as release-tags-workflow
+  # Matches the same tags as release-tags-workflow
   release-tags-job: &release-tags-job
     filters:
       tags:


### PR DESCRIPTION
### Motivation

CircleCI is [updating the regex engine used for config compilation](https://circleci.com/changelog/breaking-change-regex-engine-update-for-config-compilation/) on June 26, 2026. After that date, negative lookaheads in `when: matches: pattern:` conditions will fail to compile, breaking this pipeline.

### Description

Rewrites the `release-tags-workflow` condition as an equivalent `matches` + `not: matches` combination. The `release-tags-job` tag filter regex is unchanged: job filters are not affected by this change.