### PR TITLE
Add presentedOfferingContext support to custom paywall impression events

### DIFF
--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/CustomPaywallImpressionAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/CustomPaywallImpressionAPI.kt
@@ -12,6 +12,8 @@ private class CustomPaywallImpressionAPI {
             CustomPaywallImpressionParams(paywallId = "my-paywall")
         val paramsWithNullPaywallId: CustomPaywallImpressionParams =
             CustomPaywallImpressionParams(paywallId = null)
+        val paramsWithNullOfferingId: CustomPaywallImpressionParams =
+            CustomPaywallImpressionParams(offeringId = null)
         val paramsWithOfferingId: CustomPaywallImpressionParams =
             CustomPaywallImpressionParams(offeringId = "my-offering")
         val paramsWithBoth: CustomPaywallImpressionParams =

--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/CustomPaywallImpressionAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/CustomPaywallImpressionAPI.kt
@@ -1,15 +1,16 @@
 package com.revenuecat.purchases.kmp.apitester
 
 import com.revenuecat.purchases.kmp.models.CustomPaywallImpressionParams
+import com.revenuecat.purchases.kmp.models.Offering
 
-@Suppress("unused", "UNUSED_VARIABLE")
+@Suppress("unused", "UNUSED_VARIABLE", "DEPRECATION")
 private class CustomPaywallImpressionAPI {
     fun check() {
         // CustomPaywallImpressionParams constructors
         val defaultParams: CustomPaywallImpressionParams = CustomPaywallImpressionParams()
         val paramsWithId: CustomPaywallImpressionParams =
             CustomPaywallImpressionParams(paywallId = "my-paywall")
-        val paramsWithNull: CustomPaywallImpressionParams =
+        val paramsWithNullPaywallId: CustomPaywallImpressionParams =
             CustomPaywallImpressionParams(paywallId = null)
         val paramsWithOfferingId: CustomPaywallImpressionParams =
             CustomPaywallImpressionParams(offeringId = "my-offering")
@@ -19,5 +20,20 @@ private class CustomPaywallImpressionAPI {
         // CustomPaywallImpressionParams properties
         val paywallId: String? = paramsWithId.paywallId
         val offeringId: String? = paramsWithOfferingId.offeringId
+    }
+
+    fun checkWithOffering(offering: Offering) {
+        // CustomPaywallImpressionParams constructors
+        val paramsWithOffering: CustomPaywallImpressionParams =
+            CustomPaywallImpressionParams(offering = offering)
+        val paramsWithOfferingAndLegacyId: CustomPaywallImpressionParams =
+            CustomPaywallImpressionParams(
+                paywallId = "my-paywall",
+                offering = offering,
+                offeringId = "legacy-offering",
+            )
+
+        // CustomPaywallImpressionParams properties
+        val offeringProperty: Offering? = paramsWithOffering.offering
     }
 }

--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/CustomPaywallImpressionAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/CustomPaywallImpressionAPI.kt
@@ -28,12 +28,6 @@ private class CustomPaywallImpressionAPI {
         // CustomPaywallImpressionParams constructors
         val paramsWithOffering: CustomPaywallImpressionParams =
             CustomPaywallImpressionParams(offering = offering)
-        val paramsWithOfferingAndLegacyId: CustomPaywallImpressionParams =
-            CustomPaywallImpressionParams(
-                paywallId = "my-paywall",
-                offering = offering,
-                offeringId = "legacy-offering",
-            )
 
         // CustomPaywallImpressionParams properties
         val offeringProperty: Offering? = paramsWithOffering.offering

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/CustomPaywallTrackingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/CustomPaywallTrackingScreen.kt
@@ -33,26 +33,54 @@ fun CustomPaywallTrackingScreen(
     navigateTo: (Screen) -> Unit
 ) {
     var paywallId by remember { mutableStateOf("") }
-    var offeringId by remember { mutableStateOf("") }
     var statusMessage by remember { mutableStateOf<String?>(null) }
     var messageColor by remember { mutableStateOf(Color.Gray) }
 
-    fun trackImpression() {
-        val trimmedPaywallId = paywallId.trim().ifEmpty { null }
-        val trimmedOfferingId = offeringId.trim().ifEmpty { null }
+    fun currentPaywallId(): String? {
+        return paywallId.trim().ifEmpty { null }
+    }
 
-        if (trimmedPaywallId == null && trimmedOfferingId == null) {
+    fun trackImpressionWithoutOffering() {
+        val trimmedPaywallId = currentPaywallId()
+
+        if (trimmedPaywallId == null) {
             Purchases.sharedInstance.trackCustomPaywallImpression()
         } else {
             Purchases.sharedInstance.trackCustomPaywallImpression(
-                CustomPaywallImpressionParams(
-                    paywallId = trimmedPaywallId,
-                    offeringId = trimmedOfferingId,
-                )
+                CustomPaywallImpressionParams(paywallId = trimmedPaywallId)
             )
         }
-        statusMessage = "Tracked (paywallId: ${trimmedPaywallId ?: "nil"}, offeringId: ${trimmedOfferingId ?: "nil"})"
+        statusMessage = "Tracked without offering (paywallId: ${trimmedPaywallId ?: "nil"})"
         messageColor = Color.Green
+    }
+
+    fun trackImpressionWithCurrentOffering() {
+        val trimmedPaywallId = paywallId.trim().ifEmpty { null }
+
+        Purchases.sharedInstance.getOfferings(
+            onError = { error ->
+                statusMessage = "Failed to get offerings: $error"
+                messageColor = Color.Red
+            },
+            onSuccess = { offerings ->
+                val currentOffering = offerings.current
+                if (currentOffering == null) {
+                    statusMessage = "No current offering configured"
+                    messageColor = Color.Red
+                    return@getOfferings
+                }
+
+                Purchases.sharedInstance.trackCustomPaywallImpression(
+                    CustomPaywallImpressionParams(
+                        paywallId = trimmedPaywallId,
+                        offering = currentOffering,
+                    )
+                )
+                statusMessage =
+                    "Tracked with offering: ${currentOffering.identifier} (paywallId: ${trimmedPaywallId ?: "nil"})"
+                messageColor = Color.Green
+            }
+        )
     }
 
     Column(
@@ -88,23 +116,22 @@ fun CustomPaywallTrackingScreen(
             singleLine = true,
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
-
-        OutlinedTextField(
-            value = offeringId,
-            onValueChange = { offeringId = it },
-            label = { Text("Offering ID (optional)") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-        )
-
         Spacer(modifier = Modifier.height(16.dp))
 
         Button(
-            onClick = { trackImpression() },
+            onClick = { trackImpressionWithoutOffering() },
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Track Custom Paywall Impression")
+            Text("Track Custom Paywall Impression Without Offering")
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Button(
+            onClick = { trackImpressionWithCurrentOffering() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Track Custom Paywall Impression With Current Offering")
         }
 
         Spacer(modifier = Modifier.height(24.dp))

--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
@@ -17,6 +17,7 @@ import com.revenuecat.purchases.kmp.mappings.toAndroidBillingFeature
 import com.revenuecat.purchases.kmp.mappings.toAndroidCacheFetchPolicy
 import com.revenuecat.purchases.kmp.mappings.toAndroidEntitlementVerificationMode
 import com.revenuecat.purchases.kmp.mappings.toAndroidGoogleReplacementMode
+import com.revenuecat.purchases.kmp.mappings.toAndroidOffering
 import com.revenuecat.purchases.kmp.mappings.toAndroidPackage
 import com.revenuecat.purchases.kmp.mappings.toAndroidPurchasesAreCompletedBy
 import com.revenuecat.purchases.kmp.mappings.toAndroidStore
@@ -598,12 +599,23 @@ public actual class Purchases private constructor(private val androidPurchases: 
     public actual fun trackCustomPaywallImpression(
         params: KmpCustomPaywallImpressionParams,
     ) {
-        androidPurchases.trackCustomPaywallImpression(
+        val paywallId = params.paywallId
+        @Suppress("DEPRECATION")
+        val offeringId = params.offeringId
+        val androidParams = params.offering?.let { offering ->
             AndroidCustomPaywallImpressionParams(
-                paywallId = params.paywallId,
-                offeringId = params.offeringId,
+                paywallId = paywallId,
+                offering = offering.toAndroidOffering(),
             )
-        )
+        } ?: run {
+            @Suppress("DEPRECATION")
+            AndroidCustomPaywallImpressionParams(
+                paywallId = paywallId,
+                offeringId = offeringId,
+            )
+        }
+
+        androidPurchases.trackCustomPaywallImpression(androidParams)
     }
 
     @ExperimentalRevenueCatApi

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -6,6 +6,7 @@ import com.revenuecat.purchases.kmp.mappings.toCustomerInfo
 import com.revenuecat.purchases.kmp.mappings.toIntroEligibilityStatus
 import com.revenuecat.purchases.kmp.mappings.toIosCacheFetchPolicy
 import com.revenuecat.purchases.kmp.mappings.toIosEntitlementVerificationMode
+import com.revenuecat.purchases.kmp.mappings.toIosOffering
 import com.revenuecat.purchases.kmp.mappings.toIosPackage
 import com.revenuecat.purchases.kmp.mappings.toIosPromotionalOffer
 import com.revenuecat.purchases.kmp.mappings.toIosPurchasesAreCompletedBy
@@ -799,12 +800,23 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
             )
             return
         }
-        iosPurchases.trackCustomPaywallImpression(
+        val paywallId = params.paywallId
+        @Suppress("DEPRECATION")
+        val offeringId = params.offeringId
+        val iosParams = params.offering?.let { offering ->
             RCCustomPaywallImpressionParams(
-                paywallId = params.paywallId,
-                offeringId = params.offeringId
+                paywallId = paywallId,
+                offering = offering.toIosOffering(),
             )
-        )
+        } ?: run {
+            @Suppress("DEPRECATION")
+            RCCustomPaywallImpressionParams(
+                paywallId = paywallId,
+                offeringId = offeringId
+            )
+        }
+
+        iosPurchases.trackCustomPaywallImpression(iosParams)
     }
 
     @ExperimentalRevenueCatApi

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -123,8 +123,14 @@ public final class com/revenuecat/purchases/kmp/models/CacheFetchPolicy$Companio
 
 public final class com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParams {
 	public fun <init> ()V
+	public fun <init> (Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getOffering ()Lcom/revenuecat/purchases/kmp/models/Offering;
 	public final fun getOfferingId ()Ljava/lang/String;
 	public final fun getPaywallId ()Ljava/lang/String;
 }

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -123,11 +123,9 @@ public final class com/revenuecat/purchases/kmp/models/CacheFetchPolicy$Companio
 
 public final class com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParams {
 	public fun <init> ()V
-	public fun <init> (Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/Offering;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/Offering;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/Offering;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getOffering ()Lcom/revenuecat/purchases/kmp/models/Offering;

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -681,8 +681,14 @@ final class com.revenuecat.purchases.kmp.models/AdRevenuePrecision { // com.reve
 }
 
 final class com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams { // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams|null[0]
-    constructor <init>(kotlin/String? = ..., kotlin/String? = ...) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?;kotlin.String?){}[0]
+    constructor <init>() // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(){}[0]
+    constructor <init>(com.revenuecat.purchases.kmp.models/Offering, kotlin/String? = ...) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(com.revenuecat.purchases.kmp.models.Offering;kotlin.String?){}[0]
+    constructor <init>(kotlin/String? = ..., com.revenuecat.purchases.kmp.models/Offering, kotlin/String?) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?;com.revenuecat.purchases.kmp.models.Offering;kotlin.String?){}[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String?) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?;kotlin.String?){}[0]
+    constructor <init>(kotlin/String?) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?){}[0]
 
+    final val offering // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.offering|{}offering[0]
+        final fun <get-offering>(): com.revenuecat.purchases.kmp.models/Offering? // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.offering.<get-offering>|<get-offering>(){}[0]
     final val offeringId // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.offeringId|{}offeringId[0]
         final fun <get-offeringId>(): kotlin/String? // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.offeringId.<get-offeringId>|<get-offeringId>(){}[0]
     final val paywallId // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.paywallId|{}paywallId[0]

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -682,8 +682,7 @@ final class com.revenuecat.purchases.kmp.models/AdRevenuePrecision { // com.reve
 
 final class com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams { // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams|null[0]
     constructor <init>() // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(){}[0]
-    constructor <init>(com.revenuecat.purchases.kmp.models/Offering, kotlin/String? = ...) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(com.revenuecat.purchases.kmp.models.Offering;kotlin.String?){}[0]
-    constructor <init>(kotlin/String? = ..., com.revenuecat.purchases.kmp.models/Offering, kotlin/String?) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?;com.revenuecat.purchases.kmp.models.Offering;kotlin.String?){}[0]
+    constructor <init>(kotlin/String? = ..., com.revenuecat.purchases.kmp.models/Offering) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?;com.revenuecat.purchases.kmp.models.Offering){}[0]
     constructor <init>(kotlin/String? = ..., kotlin/String?) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?;kotlin.String?){}[0]
     constructor <init>(kotlin/String?) // com.revenuecat.purchases.kmp.models/CustomPaywallImpressionParams.<init>|<init>(kotlin.String?){}[0]
 

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParams.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParams.kt
@@ -4,10 +4,97 @@ package com.revenuecat.purchases.kmp.models
  * Parameters for tracking a custom paywall impression event.
  *
  * @param paywallId An optional identifier for the custom paywall being shown.
- * @param offeringId An optional identifier for the offering associated with the custom paywall.
- * If not provided, the SDK will use the current offering identifier from the cache.
+ * @param offeringId [Deprecated] Use [offering] instead. Optional identifier for the offering associated
+ * with the custom paywall.
+ * @property offering The [Offering] associated with the custom paywall, if provided.
  */
-public class CustomPaywallImpressionParams(
+public class CustomPaywallImpressionParams private constructor(
     public val paywallId: String? = null,
+    @Deprecated(
+        message = "Pass an Offering object instead. Using an offering identifier string prevents " +
+            "the SDK from deriving placement and targeting context automatically.",
+    )
     public val offeringId: String? = null,
-)
+    public val offering: Offering?,
+) {
+    /**
+     * Creates parameters with no offering information. No offering data is sent and the native SDK
+     * chooses the current offering.
+     */
+    public constructor() : this(
+        paywallId = null,
+        offeringId = null,
+        offering = null,
+    )
+
+    /**
+     * Creates parameters with only a paywall identifier. No offering data is sent and the native SDK
+     * chooses the current offering.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     */
+    public constructor(
+        paywallId: String?,
+    ) : this(
+        paywallId = paywallId,
+        offeringId = null,
+        offering = null,
+    )
+
+    /**
+     * Creates parameters with an offering identifier string.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     * @param offeringId [Deprecated] Use [offering] instead. Optional identifier for the offering associated
+     * with the custom paywall.
+     * @deprecated Pass an [Offering] object instead. Using an offering identifier string prevents
+     * the SDK from deriving placement and targeting context automatically.
+     */
+    @Deprecated(
+        message = "Pass an Offering object instead. Using an offering identifier string prevents " +
+            "the SDK from deriving placement and targeting context automatically.",
+    )
+    public constructor(
+        paywallId: String? = null,
+        offeringId: String?,
+    ) : this(
+        paywallId = paywallId,
+        offeringId = offeringId,
+        offering = null,
+    )
+
+    /**
+     * Creates parameters from the offering the custom paywall was obtained from.
+     *
+     * Use this constructor when presenting a paywall for an offering that is not the current
+     * offering, for example a placement-resolved offering. The SDK will derive both the offering
+     * identifier and the presented offering context from the provided offering.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     * @param offering The [Offering] associated with the custom paywall.
+     */
+    public constructor(
+        offering: Offering,
+        paywallId: String? = null,
+    ) : this(paywallId, offering.identifier, offering)
+
+    /**
+     * Creates parameters from the offering the custom paywall was obtained from.
+     *
+     * When both [offering] and [offeringId] are provided, [offering] wins.
+     *
+     * @param paywallId An optional identifier for the custom paywall being shown.
+     * @param offering The [Offering] associated with the custom paywall.
+     * @param offeringId [Deprecated] Use [offering] instead. Ignored when [offering] is provided.
+     */
+    @Deprecated(
+        message = "Pass only an Offering object instead. The offeringId is ignored when Offering is provided.",
+        replaceWith = ReplaceWith("CustomPaywallImpressionParams(offering, paywallId)"),
+    )
+    public constructor(
+        paywallId: String? = null,
+        offering: Offering,
+        @Suppress("UNUSED_PARAMETER")
+        offeringId: String?,
+    ) : this(paywallId, offering.identifier, offering)
+}

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParams.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParams.kt
@@ -53,6 +53,7 @@ public class CustomPaywallImpressionParams private constructor(
     @Deprecated(
         message = "Pass an Offering object instead. Using an offering identifier string prevents " +
             "the SDK from deriving placement and targeting context automatically.",
+        replaceWith = ReplaceWith("CustomPaywallImpressionParams(paywallId, offering)"),
     )
     public constructor(
         paywallId: String? = null,
@@ -74,27 +75,7 @@ public class CustomPaywallImpressionParams private constructor(
      * @param offering The [Offering] associated with the custom paywall.
      */
     public constructor(
-        offering: Offering,
-        paywallId: String? = null,
-    ) : this(paywallId, offering.identifier, offering)
-
-    /**
-     * Creates parameters from the offering the custom paywall was obtained from.
-     *
-     * When both [offering] and [offeringId] are provided, [offering] wins.
-     *
-     * @param paywallId An optional identifier for the custom paywall being shown.
-     * @param offering The [Offering] associated with the custom paywall.
-     * @param offeringId [Deprecated] Use [offering] instead. Ignored when [offering] is provided.
-     */
-    @Deprecated(
-        message = "Pass only an Offering object instead. The offeringId is ignored when Offering is provided.",
-        replaceWith = ReplaceWith("CustomPaywallImpressionParams(offering, paywallId)"),
-    )
-    public constructor(
         paywallId: String? = null,
         offering: Offering,
-        @Suppress("UNUSED_PARAMETER")
-        offeringId: String?,
     ) : this(paywallId, offering.identifier, offering)
 }

--- a/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParamsTest.kt
+++ b/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParamsTest.kt
@@ -33,6 +33,14 @@ class CustomPaywallImpressionParamsTest {
     }
 
     @Test
+    fun `constructor with null offeringId`() {
+        val params = CustomPaywallImpressionParams(offeringId = null)
+        assertNotNull(params)
+        assertNull(params.paywallId)
+        assertNull(params.offeringId)
+    }
+
+    @Test
     fun `constructor with offeringId only`() {
         val params = CustomPaywallImpressionParams(offeringId = "my-offering")
         assertNotNull(params)

--- a/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParamsTest.kt
+++ b/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParamsTest.kt
@@ -96,21 +96,6 @@ class CustomPaywallImpressionParamsTest {
         assertEquals(offering, params.offering)
     }
 
-    @Test
-    fun `constructor with offering and legacy offeringId uses offering`() {
-        val offering = FakeOffering(identifier = "my-offering")
-        val params = CustomPaywallImpressionParams(
-            paywallId = "my-paywall",
-            offering = offering,
-            offeringId = "legacy-offering",
-        )
-
-        assertNotNull(params)
-        assertEquals("my-paywall", params.paywallId)
-        assertEquals("my-offering", params.offeringId)
-        assertEquals(offering, params.offering)
-    }
-
     private class FakeOffering(
         override val identifier: String,
     ) : Offering {

--- a/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParamsTest.kt
+++ b/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/CustomPaywallImpressionParamsTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
+@Suppress("DEPRECATION")
 class CustomPaywallImpressionParamsTest {
 
     @Test
@@ -28,6 +29,7 @@ class CustomPaywallImpressionParamsTest {
         val params = CustomPaywallImpressionParams(paywallId = null)
         assertNotNull(params)
         assertNull(params.paywallId)
+        assertNull(params.offeringId)
     }
 
     @Test
@@ -47,5 +49,73 @@ class CustomPaywallImpressionParamsTest {
         assertNotNull(params)
         assertEquals("my-paywall", params.paywallId)
         assertEquals("my-offering", params.offeringId)
+    }
+
+    @Test
+    fun `constructor preserves empty paywallId and offeringId`() {
+        val params = CustomPaywallImpressionParams(
+            paywallId = "",
+            offeringId = "",
+        )
+
+        assertNotNull(params)
+        assertEquals("", params.paywallId)
+        assertEquals("", params.offeringId)
+    }
+
+    @Test
+    fun `constructor with offering populates offeringId from offering`() {
+        val offering = FakeOffering(identifier = "my-offering")
+        val params = CustomPaywallImpressionParams(
+            paywallId = "my-paywall",
+            offering = offering,
+        )
+
+        assertNotNull(params)
+        assertEquals("my-paywall", params.paywallId)
+        assertEquals("my-offering", params.offeringId)
+        assertEquals(offering, params.offering)
+    }
+
+    @Test
+    fun `constructor with offering defaults paywallId to null`() {
+        val offering = FakeOffering(identifier = "my-offering")
+        val params = CustomPaywallImpressionParams(offering = offering)
+
+        assertNotNull(params)
+        assertNull(params.paywallId)
+        assertEquals("my-offering", params.offeringId)
+        assertEquals(offering, params.offering)
+    }
+
+    @Test
+    fun `constructor with offering and legacy offeringId uses offering`() {
+        val offering = FakeOffering(identifier = "my-offering")
+        val params = CustomPaywallImpressionParams(
+            paywallId = "my-paywall",
+            offering = offering,
+            offeringId = "legacy-offering",
+        )
+
+        assertNotNull(params)
+        assertEquals("my-paywall", params.paywallId)
+        assertEquals("my-offering", params.offeringId)
+        assertEquals(offering, params.offering)
+    }
+
+    private class FakeOffering(
+        override val identifier: String,
+    ) : Offering {
+        override val serverDescription: String = "server description"
+        override val metadata: Map<String, Any> = emptyMap()
+        override val availablePackages: List<Package> = emptyList()
+        override val lifetime: Package? = null
+        override val annual: Package? = null
+        override val sixMonth: Package? = null
+        override val threeMonth: Package? = null
+        override val twoMonth: Package? = null
+        override val monthly: Package? = null
+        override val weekly: Package? = null
+        override val webCheckoutUrl: String? = null
     }
 }


### PR DESCRIPTION
Based on PHC PR https://github.com/RevenueCat/purchases-hybrid-common/pull/1665.

## API

We will now send the `presentedOfferingContext` from the passed `Offering` along with the event. This PR adds the new API variant that takes an `Offering` instead of a plain string `offeringId`. The latter is now deprecated in favor of this new API variant. We will derive the `presentedOfferingContext` from this `Offering` and send it along with the request.

```kotlin
Purchases.sharedInstance.trackCustomPaywallImpression(
    CustomPaywallImpressionParams(paywallId = "", offering = offering),
)
```
