### PR TITLE
Update sdks-common-config orb to 3.21.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.5.0
-  revenuecat: revenuecat/sdks-common-config@3.21.1
+  revenuecat: revenuecat/sdks-common-config@3.21.2
 
 commands:
   install-android-sdk-on-macos:


### PR DESCRIPTION
### Motivation
Pull in [sdks-circleci-orb#69](https://github.com/RevenueCat/sdks-circleci-orb/pull/69), which fixes the `merge-release-pr` job failing after a successful merge.

### Description
Bump the CircleCI orb to `3.21.2`.
