### PR TITLE
Bump sdks-common-config orb to 4.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.5.0
-  revenuecat: revenuecat/sdks-common-config@4.0.0
+  revenuecat: revenuecat/sdks-common-config@4.1.0
 
 commands:
   install-android-sdk-on-macos:


### PR DESCRIPTION
Bump common config orb to 4.1.0 to include error codes reminder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI orb version pin with no application or SDK runtime changes; risk is limited to possible orb behavior differences in CircleCI jobs.
> 
> **Overview**
> Updates the shared CircleCI **`revenuecat/sdks-common-config`** orb from **4.0.0** to **4.1.0** in `.circleci/config.yml`.
> 
> This pulls in the orb’s **error codes reminder** behavior for SDK pipelines that already use RevenueCat common jobs (e.g. `update-error-codes`, release train, Danger).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730ab4fc92c92c78dc5213592473858691f2357b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->