### PR TITLE
Fix CircleCI release tag regex for upcoming deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ aliases:
             matches: { pattern: ".*-SNAPSHOT.*", value: << pipeline.git.tag >> }
         - not:
             equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-  # Matches the same tags as release-tags-workflow
   release-tags-job: &release-tags-job
     filters:
       tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ aliases:
   release-tags-job: &release-tags-job
     filters:
       tags:
-        only: /^[0-9]+\.[0-9]+\.[0-9]+(?!.*-SNAPSHOT).*$/
+        only: /^[0-9]+\.[0-9]+\.[0-9]+.*$/
+        ignore: /^.*-SNAPSHOT/
       branches:
         ignore: /.*/
 


### PR DESCRIPTION
One of the items mentioned in the change log for the upcoming [CircleCI config deprecation](https://circleci.com/changelog/upcoming-config-compilation-breaking-changes) is the removal of negative lookaheads in regex patterns.

We were using this in the release tags job branch filter, by checking for a matching semver that is not a snapshot version. For example
- `1.2.3` would pass
- `1.2.3-SNAPSHOT` would not pass

I've updated this to separate the regexes into the `only` and `ignore` patterns on the branch filters, in order to achieve the same goal without using negative lookaheads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only tag filter change with equivalent matching logic; no application or release artifact code is touched.
> 
> **Overview**
> Updates the **`release-tags-job`** tag filter in `.circleci/config.yml` so release pipelines keep the same semver-vs-SNAPSHOT behavior after CircleCI drops negative lookaheads in config regex.
> 
> The single **`only`** pattern that used `(?!.*-SNAPSHOT)` is replaced with **`only: /^[0-9]+\.[0-9]+\.[0-9]+.*$/`** plus **`ignore: /^.*-SNAPSHOT/`**, so tags like `1.2.3` still run publish/GitHub release jobs while `1.2.3-SNAPSHOT` does not. A stale comment tying this alias to the workflow block was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63dd4efff8092fee26cf7ca3b108a47733be5c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->