### PR TITLE
Run Danger on release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,6 +409,16 @@ jobs:
           command: bundle exec fastlane github_release_current_version
 
 workflows:
+  danger:
+    when:
+      and:
+        - not:
+            equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ build, << pipeline.parameters.action >> ]
+    jobs:
+      - revenuecat/danger:
+          context: danger-bot
+
   # This workflow runs for any commit to main, as well as for any other
   # branch with an open PR, except for release branches. This is controlled 
   # by the "Only build pull requests" setting on CircleCI. 
@@ -421,8 +431,6 @@ workflows:
             matches: { pattern: "^release/.+$", value: << pipeline.git.branch >> }
         - equal: [ build, << pipeline.parameters.action >> ]
     jobs:
-      - revenuecat/danger:
-          context: danger-bot
       - detekt
       - unit-tests-build-logic
       - build-libraries-android


### PR DESCRIPTION
It looks like `revenuecat/danger` no longer runs on the release [PR](https://github.com/RevenueCat/purchases-kmp/pull/919). 

I'm not quite sure how / why it did work before, as it doesn't seem configured in the `circleci.yml` file. This PR should add it back. 

Update: this was most likely due to the `revenuecat/danger` check being added to the list of required status checks, even though Danger never ran on release PRs in KMP. Since KMP was the only one not doing this on release PRs I've now aligned this with the others. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; mirrors an existing job from another workflow with no application or publish logic changes.
> 
> **Overview**
> **Restores Danger on release PRs** by adding `revenuecat/danger` (with `danger-bot` context) to the `on-release-branch` CircleCI workflow.
> 
> Release branches are excluded from `on-non-release-branch`, where Danger already runs, so release train PRs were no longer getting those automated checks until this job was added alongside the existing detekt/build/test pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98223a2a09c3c4d6e20332fb318e9e83df422fd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->