### PR TITLE
ci: bump sdks-common-config orb to 4.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.5.0
-  revenuecat: revenuecat/sdks-common-config@4.4.0
+  revenuecat: revenuecat/sdks-common-config@4.5.0
 
 commands:
   install-android-sdk-on-macos:


### PR DESCRIPTION
### Motivation

`danger` and `automatic-bump` relied on the orb's old default Ruby `3.1.2`, which no longer satisfies gems requiring Ruby >= 3.2 — `bundle install` fails as Bundler backtracks to an unbuildable `nokogiri`.

### Summary

- Bump `revenuecat/sdks-common-config` to `4.5.0`, whose `danger`/`automatic-bump` default to Ruby 3.2.0 (sdks-circleci-orb#81).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI dependency version bump with no application or runtime code changes.
> 
> **Overview**
> Updates CircleCI to use **`revenuecat/sdks-common-config@4.5.0`** (from `4.4.0`).
> 
> That orb version defaults **`danger`** and **`automatic-bump`** to Ruby **3.2.0**, which fixes **`bundle install`** failures when gems require Ruby ≥ 3.2 (e.g. Bundler resolving to an unbuildable **`nokogiri`** on the old **3.1.2** default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 581bd0ed9c660987e852b310acfd2f1cba5046be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->