### PR TITLE
Add internal support for enabling workflows

### DIFF
--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/PurchasesCommonAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/PurchasesCommonAPI.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.kmp.apitester
 
 import arrow.core.Either
+import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
 import com.revenuecat.purchases.kmp.LogHandler
 import com.revenuecat.purchases.kmp.LogLevel
 import com.revenuecat.purchases.kmp.Purchases
@@ -333,6 +334,7 @@ private class PurchasesCommonAPI {
     }
 
     @Suppress("ForbiddenComment")
+    @OptIn(ExperimentalRevenueCatApi::class)
     fun checkConfiguration() {
         val features: List<BillingFeature> = ArrayList()
         val configured: Boolean = Purchases.isConfigured
@@ -353,7 +355,7 @@ private class PurchasesCommonAPI {
             showInAppMessagesAutomatically = true
             store = Store.PLAY_STORE
             diagnosticsEnabled = true
-            dangerousSettings = DangerousSettings(autoSyncPurchases = true)
+            dangerousSettings = DangerousSettings(autoSyncPurchases = true, useWorkflows = true)
             verificationMode = EntitlementVerificationMode.INFORMATIONAL
             pendingTransactionsForPrepaidPlansEnabled = true
             preferredUILocaleOverride = "de_DE"

--- a/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
+++ b/core/src/androidMain/kotlin/com/revenuecat/purchases/kmp/Purchases.android.kt
@@ -64,6 +64,7 @@ import com.revenuecat.purchases.syncAttributesAndOfferingsIfNeededWith
 import com.revenuecat.purchases.syncPurchasesWith
 import java.net.URL
 import com.revenuecat.purchases.DangerousSettings as AndroidDangerousSettings
+import com.revenuecat.purchases.InternalRevenueCatAPI
 import com.revenuecat.purchases.Purchases as AndroidPurchases
 import com.revenuecat.purchases.PurchasesConfiguration as AndroidPurchasesConfiguration
 import com.revenuecat.purchases.kmp.models.CustomPaywallImpressionParams as KmpCustomPaywallImpressionParams
@@ -148,8 +149,13 @@ public actual class Purchases private constructor(private val androidPurchases: 
             features = features.map { it.toAndroidBillingFeature() },
         ) { result -> callback(result) }
 
+        @OptIn(InternalRevenueCatAPI::class)
         private fun DangerousSettings.toAndroidDangerousSettings(): AndroidDangerousSettings =
-            AndroidDangerousSettings(autoSyncPurchases)
+            if (useWorkflows) {
+                AndroidDangerousSettings.forWorkflows(autoSyncPurchases)
+            } else {
+                AndroidDangerousSettings(autoSyncPurchases)
+            }
 
         public actual fun parseAsWebPurchaseRedemption(url: String): WebPurchaseRedemption? {
             return if (AndroidPurchases.parseAsWebPurchaseRedemption(url) != null) {

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -62,6 +62,7 @@ import com.revenuecat.purchases.kn.core.overridePreferredUILocale
 import com.revenuecat.purchases.kn.core.RCStoreTransaction
 import com.revenuecat.purchases.kn.core.RCVirtualCurrencies
 import com.revenuecat.purchases.kn.core.additional.AppleApiAvailability
+import com.revenuecat.purchases.kn.core.additional.DangerousSettingsFactory
 import com.revenuecat.purchases.kn.core.configureWithConfiguration
 import com.revenuecat.purchases.kn.core.enableAdServicesAttributionTokenCollection
 import com.revenuecat.purchases.kn.core.parseAsWebPurchaseRedemption
@@ -146,7 +147,8 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         }
 
         private fun DangerousSettings.toIosDangerousSettings(): IosDangerousSettings =
-            IosDangerousSettings(autoSyncPurchases)
+            DangerousSettingsFactory.makeWithAutoSyncPurchases(autoSyncPurchases, useWorkflows)
+                as IosDangerousSettings
 
         public actual fun parseAsWebPurchaseRedemption(url: String): WebPurchaseRedemption? {
             return if (IosPurchases.parseAsWebPurchaseRedemption(NSURL(string = url)) != null) {

--- a/kn-core/src/swift/Package.swift
+++ b/kn-core/src/swift/Package.swift
@@ -13,8 +13,16 @@ let package = Package(
     products: [
         .library(name: "AdditionalSwift", targets: ["AdditionalSwift"])
     ],
+    dependencies: [
+        .package(path: "../../../upstream/purchases-ios")
+    ],
     targets: [
-        .target(name: "AdditionalSwift")
+        .target(
+            name: "AdditionalSwift",
+            dependencies: [
+                .product(name: "RevenueCat", package: "purchases-ios")
+            ]
+        )
     ]
 )
 

--- a/kn-core/src/swift/Sources/AdditionalSwift/DangerousSettingsFactory.swift
+++ b/kn-core/src/swift/Sources/AdditionalSwift/DangerousSettingsFactory.swift
@@ -1,0 +1,13 @@
+import Foundation
+@_spi(Internal) import RevenueCat
+
+@objc
+public class DangerousSettingsFactory: NSObject {
+    @objc
+    public static func make(autoSyncPurchases: Bool, useWorkflows: Bool) -> Any {
+        if useWorkflows {
+            return DangerousSettings(useWorkflows: true)
+        }
+        return DangerousSettings(autoSyncPurchases: autoSyncPurchases)
+    }
+}

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/DangerousSettings.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/DangerousSettings.kt
@@ -1,5 +1,7 @@
 package com.revenuecat.purchases.kmp.models
 
+import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+
 /**
  * Only use a Dangerous Setting if suggested by RevenueCat support team.
  */
@@ -11,4 +13,8 @@ public class DangerousSettings(
      * purchases is enabled by default.
      */
     public val autoSyncPurchases: Boolean = true,
+    /**
+     * Enables RevenueCat Workflows (multipage paywalls). Internal RevenueCat use only.
+     */
+    @ExperimentalRevenueCatApi public val useWorkflows: Boolean = false,
 )


### PR DESCRIPTION
## What changed

Adds an experimental `useWorkflows` field to KMP `DangerousSettings`, defaulting to `false`, and maps it to the native SDK configuration:

- Android uses the internal `DangerousSettings.forWorkflows(autoSyncPurchases)` API.
- iOS uses a small Swift factory to reach the `@_spi(Internal)` workflow initializer, which is unavailable through the generated bindings.

The API-tester fixture covers the new experimental field.

## Verification
- [x] `:core:compileKotlinIosArm64`
- [x] `:core:compileDebugKotlinAndroid`
- [x] `:apiTester:compileKotlinIosArm64`

This mirrors purchases-unity#996 and react-native-purchases#1847. Defaults remain unchanged when the option is omitted.