### PR TITLE
Wire mise into CI for JDK and Ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - run:
           name: Run Detekt on commonMain
@@ -181,6 +183,8 @@ jobs:
       - install-android-sdk-on-macos
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
@@ -194,6 +198,8 @@ jobs:
     executor: android202409
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - attach-workspace-at-working-directory
       - run:
@@ -214,6 +220,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
@@ -237,6 +245,8 @@ jobs:
     executor: android202409
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - attach-workspace-at-working-directory
       - run:
@@ -254,6 +264,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
@@ -283,6 +295,8 @@ jobs:
     executor: android202409
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - attach-workspace-at-working-directory
       - run:
@@ -300,6 +314,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
@@ -320,6 +336,8 @@ jobs:
     executor: android202409
     steps:
       - checkout
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - attach-workspace-at-working-directory
       - run:
@@ -337,6 +355,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - restore-kotlin-native-compiler-from-cache
       - attach-workspace-at-working-directory
@@ -356,6 +376,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java
       - restore-gradle-user-home-directory-from-cache
       - attach-workspace-at-working-directory
       - run:
@@ -376,6 +398,8 @@ jobs:
     steps:
       - checkout
       - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java,ruby
       - install-android-sdk-on-macos
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
@@ -486,6 +510,8 @@ workflows:
           update_api_steps:
             - install-android-sdk-on-macos
             - checkout-submodule
+            - revenuecat/install-mise-tools:
+                tools: java,ruby
             - restore-gradle-user-home-directory-from-cache
             - restore-kotlin-native-compiler-from-cache
             - revenuecat/install-gem-mac-dependencies:

--- a/mise.lock
+++ b/mise.lock
@@ -3,3 +3,48 @@
 [[tools.java]]
 version = "liberica-17.0.6+10"
 backend = "core:java"
+
+[tools.java."platforms.linux-arm64"]
+checksum = "sha1:3f35ee9fac9ab87b163333bc6c7802753730a680"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-aarch64.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha1:3921ead0629aa003b3ec3afad7557bbea397fb1e"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-linux-amd64.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha1:2af64f6f557c6cbf96cac7022eba2c9779a6be7a"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-macos-aarch64.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha1:e78e899e7a6449751c5431d53a9cb9ed001da90d"
+url = "https://github.com/bell-sw/Liberica/releases/download/17.0.6%2B10/bellsoft-jdk17.0.6%2B10-macos-amd64.tar.gz"
+
+[[tools.ruby]]
+version = "3.3.0"
+backend = "core:ruby"
+
+[tools.ruby.options]
+compile = "false"
+precompiled_url = "jdx/ruby"
+ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
+ruby_install = "false"
+
+[tools.ruby."platforms.linux-arm64"]
+checksum = "sha256:d03e0e1dc566aa6512baffb9373be48d36d4fde3ca9b58e0184eb5113a507eda"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.arm64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.linux-x64"]
+checksum = "sha256:7b2cec2a09b60b225b2b216938332ea009cf17dd21b9a2096aeaf963df957641"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.x86_64_linux.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.macos-arm64"]
+checksum = "sha256:0f3be0a98f46c6771f546ae753a6affd5f87dda4e5fbb222424c39a7fa82a99a"
+url = "https://github.com/jdx/ruby/releases/download/3.3.0-4/ruby-3.3.0.macos.tar.gz"
+provenance = "github-attestations"
+
+[tools.ruby."platforms.macos-x64"]
+checksum = "sha256:96518814d9832bece92a85415a819d4893b307db5921ae1f0f751a9a89a56b7d"
+url = "https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.0.tar.gz"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,9 @@
 [settings]
 lockfile = true
 
+[settings.ruby]
+compile = false
+
 [tools]
 java = "liberica-17.0.6"
+ruby = "3.3.0"


### PR DESCRIPTION
Wires the JDK/Ruby pins already declared in `mise.toml` (added in #912 for local dev only) into CI, so CI actually uses them instead of whatever the executor image happens to ship.

- Adds `install-mise-tools` (`tools: java`) to all 13 Gradle-invoking jobs. Previously there was zero explicit JDK pin in CI: both the Linux (`android202409`) and macOS (`xcode16`) executors just used the image's ambient JDK.
- Adds `ruby = "3.3.0"` to `mise.toml` and wires `tools: java,ruby` into the 5 jobs that also call `install-gem-mac-dependencies` on macOS. That command never provisioned ruby itself, so macOS ruby was previously fully unpinned (no rbenv, no cimg image). Matches the Linux `ruby3` executor's existing `cimg/ruby:3.3.0`. `rb-readline` is already a direct `Gemfile` dependency, so no new readline-crash risk (fastlane#21794) from this.
- Regenerates `mise.lock` for all 4 platforms (linux/macos × arm64/x64) — it previously had version-only entries with no platform checksums.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only toolchain pinning with no application or SDK runtime changes; risk is mainly CI flakiness if mise installs fail.
> 
> **Overview**
> CI now provisions **Java** and **Ruby** from `mise.toml` / `mise.lock` instead of relying on CircleCI executor images.
> 
> **CircleCI** adds `revenuecat/install-mise-tools` before Gradle (and gem steps on macOS): `tools: java` on all Gradle jobs, and `tools: java,ruby` on macOS jobs that use `install-gem-mac-dependencies` plus `publish` and `update-error-codes` API regeneration.
> 
> **mise.toml** pins **Ruby 3.3.0** (with `compile = false`) alongside the existing Liberica JDK pin. **mise.lock** is expanded with per-platform checksums and download URLs for Java and Ruby on linux/macos arm64 and x64.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195f88e24a77f852f0268087cc4b0b88157b81de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->