### PR TITLE
Add onWebCheckoutOpened and onUrlOpened to PaywallListener

### DIFF
--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/PaywallListenerAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/PaywallListenerAPI.kt
@@ -41,6 +41,10 @@ private class PaywallListenerAPI {
             override fun onRestoreError(error: PurchasesError) {
                 super.onRestoreError(error)
             }
+
+            override fun onWebCheckoutOpened() {
+                super.onWebCheckoutOpened()
+            }
         }
     }
 }

--- a/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/PaywallListenerAPI.kt
+++ b/apiTester/src/commonMain/kotlin/com/revenuecat/purchases/kmp/apitester/PaywallListenerAPI.kt
@@ -45,6 +45,10 @@ private class PaywallListenerAPI {
             override fun onWebCheckoutOpened() {
                 super.onWebCheckoutOpened()
             }
+
+            override fun onUrlOpened(url: String) {
+                super.onUrlOpened(url)
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ java = "1.8"
 junit = "5.10.0"
 kotlin = "2.3.20"
 mavenPublish = "0.33.0"
-revenuecat-android = "10.14.1"
+revenuecat-android = "10.16.0"
 revenuecat-kmp = "3.4.0-SNAPSHOT"
 
 [libraries]

--- a/revenuecatui/api/revenuecatui.api
+++ b/revenuecatui/api/revenuecatui.api
@@ -64,6 +64,8 @@ public abstract interface class com/revenuecat/purchases/kmp/ui/revenuecatui/Pay
 	public fun onRestoreCompleted (Lcom/revenuecat/purchases/kmp/models/CustomerInfo;)V
 	public fun onRestoreError (Lcom/revenuecat/purchases/kmp/models/PurchasesError;)V
 	public fun onRestoreStarted ()V
+	public fun onUrlOpened (Ljava/lang/String;)V
+	public fun onWebCheckoutOpened ()V
 }
 
 public final class com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener$DefaultImpls {
@@ -74,6 +76,8 @@ public final class com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener$
 	public static fun onRestoreCompleted (Lcom/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener;Lcom/revenuecat/purchases/kmp/models/CustomerInfo;)V
 	public static fun onRestoreError (Lcom/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener;Lcom/revenuecat/purchases/kmp/models/PurchasesError;)V
 	public static fun onRestoreStarted (Lcom/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener;)V
+	public static fun onUrlOpened (Lcom/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener;Ljava/lang/String;)V
+	public static fun onWebCheckoutOpened (Lcom/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener;)V
 }
 
 public final class com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptions {

--- a/revenuecatui/api/revenuecatui.klib.api
+++ b/revenuecatui/api/revenuecatui.klib.api
@@ -14,6 +14,8 @@ abstract interface com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener 
     open fun onRestoreCompleted(com.revenuecat.purchases.kmp.models/CustomerInfo) // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onRestoreCompleted|onRestoreCompleted(com.revenuecat.purchases.kmp.models.CustomerInfo){}[0]
     open fun onRestoreError(com.revenuecat.purchases.kmp.models/PurchasesError) // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onRestoreError|onRestoreError(com.revenuecat.purchases.kmp.models.PurchasesError){}[0]
     open fun onRestoreStarted() // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onRestoreStarted|onRestoreStarted(){}[0]
+    open fun onUrlOpened(kotlin/String) // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onUrlOpened|onUrlOpened(kotlin.String){}[0]
+    open fun onWebCheckoutOpened() // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallListener.onWebCheckoutOpened|onWebCheckoutOpened(){}[0]
 }
 
 abstract interface com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallPurchaseLogic { // com.revenuecat.purchases.kmp.ui.revenuecatui/PaywallPurchaseLogic|null[0]

--- a/revenuecatui/src/androidMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/androidMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -111,4 +111,6 @@ private class PaywallListenerWrapper(private val listener: PaywallListener) :
         listener.onRestoreError(error.toPurchasesError())
 
     override fun onRestoreStarted() = listener.onRestoreStarted()
+
+    override fun onWebCheckoutOpened() = listener.onWebCheckoutOpened()
 }

--- a/revenuecatui/src/androidMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/androidMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -113,4 +113,6 @@ private class PaywallListenerWrapper(private val listener: PaywallListener) :
     override fun onRestoreStarted() = listener.onRestoreStarted()
 
     override fun onWebCheckoutOpened() = listener.onWebCheckoutOpened()
+
+    override fun onUrlOpened(url: String) = listener.onUrlOpened(url)
 }

--- a/revenuecatui/src/commonMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener.kt
+++ b/revenuecatui/src/commonMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener.kt
@@ -57,4 +57,13 @@ public interface PaywallListener {
      * complete payment externally.
      */
     public fun onWebCheckoutOpened() {}
+
+    /**
+     * Callback that gets called when the paywall successfully opens a URL, either from a button
+     * with a URL destination or from a link inside a text component. Not called for web checkout
+     * URLs; use [onWebCheckoutOpened] for those.
+     *
+     * @param url The URL that was opened.
+     */
+    public fun onUrlOpened(url: String) {}
 }

--- a/revenuecatui/src/commonMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener.kt
+++ b/revenuecatui/src/commonMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallListener.kt
@@ -51,4 +51,10 @@ public interface PaywallListener {
      * Callback that gets called when a restore fails.
      */
     public fun onRestoreError(error: PurchasesError) {}
+
+    /**
+     * Callback that gets called when the user taps a web checkout CTA and leaves the app to
+     * complete payment externally.
+     */
+    public fun onWebCheckoutOpened() {}
 }

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -65,6 +65,10 @@ internal class IosPaywallDelegate(
         listener?.onRestoreStarted()
     }
 
+    override fun paywallViewControllerDidOpenWebCheckout(controller: RCPaywallViewController) {
+        listener?.onWebCheckoutOpened()
+    }
+
     @Suppress("CAST_NEVER_SUCCEEDS")
     override fun paywallViewController(
         controller: RCPaywallViewController,

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -10,6 +10,7 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.pointed
 import platform.CoreGraphics.CGSize
 import platform.Foundation.NSError
+import platform.Foundation.NSURL
 import platform.darwin.NSObject
 import com.revenuecat.purchases.kn.core.RCCustomerInfo
 import com.revenuecat.purchases.kn.core.RCPackage
@@ -86,6 +87,13 @@ internal class IosPaywallDelegate(
 
     override fun paywallViewControllerDidOpenWebCheckout(controller: RCPaywallViewController) {
         listener?.onWebCheckoutOpened()
+    }
+
+    override fun paywallViewController(
+        controller: RCPaywallViewController,
+        didOpenURL: NSURL
+    ) {
+        listener?.onUrlOpened(didOpenURL.absoluteString ?: "")
     }
 
     override fun paywallViewController(

--- a/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
+++ b/revenuecatui/src/iosMain/kotlin/com/revenuecat/purchases/kmp/ui/revenuecatui/PaywallOptionsKtx.kt
@@ -65,10 +65,6 @@ internal class IosPaywallDelegate(
         listener?.onRestoreStarted()
     }
 
-    override fun paywallViewControllerDidOpenWebCheckout(controller: RCPaywallViewController) {
-        listener?.onWebCheckoutOpened()
-    }
-
     @Suppress("CAST_NEVER_SUCCEEDS")
     override fun paywallViewController(
         controller: RCPaywallViewController,
@@ -86,6 +82,10 @@ internal class IosPaywallDelegate(
         didFailRestoringWithError: NSError
     ) {
         listener?.onRestoreError(didFailRestoringWithError.toPurchasesErrorOrThrow())
+    }
+
+    override fun paywallViewControllerDidOpenWebCheckout(controller: RCPaywallViewController) {
+        listener?.onWebCheckoutOpened()
     }
 
     override fun paywallViewController(


### PR DESCRIPTION
Exposes:
- `onWebCheckoutOpened`: RevenueCat/purchases-android#3809, RevenueCat/purchases-ios#7260
- `onUrlOpened`: RevenueCat/purchases-android#3859, RevenueCat/purchases-ios#7320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API with default no-op implementations; no changes to purchase/restore flows beyond new optional callbacks.
> 
> **Overview**
> Adds two optional **`PaywallListener`** callbacks aligned with native Android/iOS paywall UI: **`onWebCheckoutOpened()`** when the user leaves the app for external web checkout, and **`onUrlOpened(url)`** for other paywall-opened URLs (with docs noting web checkout should use the former).
> 
> Android and iOS **`PaywallOptionsKtx`** bridges forward native delegate/listener events into KMP. Public API dumps and the API tester stubs are updated. **`revenuecat-android`** is bumped **10.14.1 → 10.16.0** for matching native SDK APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6c4edaa338e09cdd4df8e8ba58019cc25f5b708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

