### PR TITLE
Point the purchases-ios submodule branch at 5.83.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "upstream/purchases-ios"]
 	path = upstream/purchases-ios
 	url = git@github.com:RevenueCat/purchases-ios.git
-	branch = 5.81.2
+	branch = 5.83.0


### PR DESCRIPTION
#948 moved the `upstream/purchases-ios` submodule pointer from `5d8667fc` (5.81.2) to `c69a23f56` (5.83.0) to pick up the new paywall listener APIs, but left `branch` in `.gitmodules` at `5.81.2`. So the pointer and the declared version disagree.

<details>
<summary>AI session context</summary>

# AI Context

## Metadata

- PR: this PR
- Branch: `facu/update-purchases-ios-5.83.0`
- Author / human owner: @facumenzella
- Agent(s): Claude Code (claude-opus-5[1m])
- Session source: current conversation
- Generated: 2026-07-31
- Context document version: 1

## Goal

Bring `.gitmodules` back in sync with the `upstream/purchases-ios` submodule pointer.

## Initial Prompt

"how do we trigger a phc update in purchases-kmp?", then "how do i update ios / android dep then?", then "check the history of the repo to find the latest update, and let's copy that".

## Important Follow-up Prompts

- The intent shifted from "trigger a PHC bump" to "update the native deps" to "copy the latest bump", and the investigation ended up showing both deps were already current, leaving only this metadata drift.

## Agent Contribution

- Established that purchases-kmp does not consume purchases-hybrid-common at all: a repo-wide grep for `hybrid` returns nothing outside docs, and the stale `[bump-phc/17.41.1]` PR #697 (open since February) targets the old CocoaPods layout. So there is no PHC bump to trigger here, unlike flutter / react-native / unity.
- Mapped how natives are actually pinned: Android via `gradle/libs.versions.toml` (`revenuecat-android`), iOS via the `upstream/purchases-ios` git submodule consumed through cinterop in `kn-core` / `kn-ui`.
- Established that updates come from Renovate (`renovate.json` enables the `git-submodules` manager and groups the two Gradle artifacts as `purchases-android`), not from a fastlane bump lane. Dependabot is scoped to `bundler` only.
- Read the history of prior bumps and confirmed the shape: #946 changed `.gitmodules` + pointer (1+/1- each), #937 changed one line in `libs.versions.toml`, both labeled `pr:dependencies`.
- Verified Renovate pins the submodule to the **tag** commit, not a branch head: #946's pointer `5d8667fc` equals `git rev-parse 5.81.2^{commit}` exactly.
- Found that both bumps had already landed inside #948, and that only the `branch` field was left behind. That reduced the intended work from a two-part bump to this one line.

## Human Decisions

- Decision: mirror the existing Renovate bump convention rather than invent a new one.
- Decision: push and open the PR once the finding was reduced to the single stale line.

## Key Implementation Decisions

- Decision: change only the `branch` field and leave the submodule pointer alone.
  - Rationale: the pointer is already at the 5.83.0 tag commit, verified against `git rev-parse 5.83.0^{commit}`. Touching it would be a no-op at best.
  - Rejected: a full two-part bump copying #946, which was the original plan until the pointer turned out to be current.
- Decision: edit the file directly rather than via `git config -f .gitmodules`.
  - Rationale: keeps the tab indentation and file formatting byte-identical, so the diff is exactly one line.

## Files / Symbols Touched

- `.gitmodules`
  - Why: `branch` disagreed with the committed submodule pointer.
  - Review relevance: the whole change. Confirm 5.83.0 is the intended iOS version, which `git ls-tree HEAD upstream/purchases-ios` already reflects.

## Dependencies / Config / Migrations

- No dependency version actually changes. `revenuecat-android` is already `10.16.0` and the submodule already points at the 5.83.0 tag, both from #948.

## Validation

- Commands run:
  - `git diff`: exactly one line changed, indentation preserved.
  - `git ls-tree HEAD upstream/purchases-ios`: `c69a23f56c63bdfe96096fa64a1c65334d2592db`, unchanged by this PR.
  - `git rev-parse 5.83.0^{commit}` in purchases-ios: `c69a23f56...`, matching the pointer, so `branch = 5.83.0` is now accurate.
- Manual verification:
  - Not run. No build was performed.
- CI:
  - Not captured at time of writing.

## Validation Gaps

- No Kotlin/Native or Android build was run locally. Nothing consumes the `branch` field at build time (cinterop resolves through the pointer via `rootProject.file("upstream/purchases-ios")`), so a build is not expected to be affected, but that is reasoning rather than a green build.
- Whether Renovate now behaves as expected can only be confirmed on its next run.

## Review Focus

- Is 5.83.0 the intended iOS version to declare, or should the pointer move again as part of a larger bump?
- Should anything guard against this drift recurring, given the next hand-written PR that moves the submodule can reintroduce it?

## Risks / Reviewer Notes

- Risk: none to the build.
  - Evidence: the `branch` field is metadata for Renovate and `git submodule update --remote`; cinterop uses the pointer. `fastlane/Fastfile` reads the version from the submodule's `.version` at the pinned SHA.
  - Mitigation: not needed.

## Non-goals / Out of Scope

- Not moving the submodule pointer or any dependency version.
- Not touching the stale PHC bump PR #697, which predates KMP dropping purchases-hybrid-common and should probably just be closed.

## Omitted Context

- Raw transcript, unrelated exploration, sensitive details, repetitive attempts, and chain-of-thought-style content were omitted.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line metadata in `.gitmodules` with no dependency pointer or build-path change; no security or runtime impact.
> 
> **Overview**
> Updates the `upstream/purchases-ios` submodule **`branch`** in `.gitmodules` from `5.81.2` to `5.83.0` so it matches the commit already pinned on that submodule (from #948).
> 
> The **submodule SHA does not change** in this PR—only Renovate/git-submodule metadata. Builds still resolve iOS via the pinned commit (e.g. cinterop and Fastlane reading `.version` at that SHA), not this field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c55c7c80c091fec924e463a95ba8b409ed778e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->