### PR TITLE
build-logic groundwork for watchOS targets

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/AppleTargets.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/AppleTargets.kt
@@ -1,0 +1,14 @@
+package com.revenuecat.purchases.kmp.buildlogic
+
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * Declares all watchOS compilation targets. The `revenuecat-library` convention plugin declares
+ * Android and iOS targets for every module; modules that also support watchOS call this from
+ * their `kotlin {}` block.
+ */
+fun KotlinMultiplatformExtension.watchosTargets() {
+    watchosArm64()
+    watchosDeviceArm64()
+    watchosSimulatorArm64()
+}

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/convention/configureKotlin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/convention/configureKotlin.kt
@@ -35,8 +35,12 @@ internal fun Project.configureKotlin() {
         }
         sourceSets.all {
             languageSettings.apply {
-                if (name.lowercase().startsWith("ios")) {
+                val appleSourceSetPrefixes = listOf("apple", "ios", "watchos", "tvos", "macos")
+                if (appleSourceSetPrefixes.any { name.lowercase().startsWith(it) }) {
                     optIn("kotlinx.cinterop.ExperimentalForeignApi")
+                    // NSInteger and friends commonize to variable-width types (32 bits on
+                    // watchosArm64), which require this opt-in in shared Apple code.
+                    optIn("kotlinx.cinterop.UnsafeNumber")
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/convention/configureKotlin.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/convention/configureKotlin.kt
@@ -38,8 +38,9 @@ internal fun Project.configureKotlin() {
                 val appleSourceSetPrefixes = listOf("apple", "ios", "watchos", "tvos", "macos")
                 if (appleSourceSetPrefixes.any { name.lowercase().startsWith(it) }) {
                     optIn("kotlinx.cinterop.ExperimentalForeignApi")
-                    // NSInteger and friends commonize to variable-width types (32 bits on
-                    // watchosArm64), which require this opt-in in shared Apple code.
+                    // NSInteger and friends commonize to types of different widths on different
+                    // Apple targets (e.g. 64 bits on iOS, 32 bits on watchosArm64), which requires
+                    // this opt-in in shared Apple code.
                     optIn("kotlinx.cinterop.UnsafeNumber")
                 }
             }

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
@@ -219,7 +219,6 @@ private fun KonanTarget.isAppleTarget(): Boolean =
         // watchOS
         KonanTarget.WATCHOS_ARM64,
         KonanTarget.WATCHOS_SIMULATOR_ARM64,
-        KonanTarget.WATCHOS_X64,
         KonanTarget.WATCHOS_DEVICE_ARM64,
     )
 
@@ -310,7 +309,6 @@ private fun getTaskSuffix(konanTarget: KonanTarget): String = when (konanTarget)
     // watchOS
     KonanTarget.WATCHOS_ARM64 -> "WatchosArm64"
     KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "WatchosSimulatorArm64"
-    KonanTarget.WATCHOS_X64 -> "WatchosX64"
     KonanTarget.WATCHOS_DEVICE_ARM64 -> "WatchosDeviceArm64"
     else -> error("Unexpected target: $konanTarget")
 }
@@ -376,7 +374,7 @@ private fun KonanTarget.getSdkName(): String = when (this) {
     KonanTarget.TVOS_X64, KonanTarget.TVOS_SIMULATOR_ARM64 -> "appletvsimulator"
     KonanTarget.TVOS_ARM64 -> "appletvos"
     // watchOS
-    KonanTarget.WATCHOS_X64, KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "watchsimulator"
+    KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "watchsimulator"
     KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_DEVICE_ARM64 -> "watchos"
     else -> error("Unsupported target: ${this}")
 }
@@ -394,8 +392,10 @@ private fun KonanTarget.getTriple(): String = when (this) {
     KonanTarget.TVOS_SIMULATOR_ARM64 -> "arm64-apple-tvos-simulator"
     KonanTarget.TVOS_ARM64 -> "arm64-apple-tvos"
     // watchOS
-    KonanTarget.WATCHOS_X64 -> "x86_64-apple-watchos-simulator"
     KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "arm64-apple-watchos-simulator"
-    KonanTarget.WATCHOS_ARM64, KonanTarget.WATCHOS_DEVICE_ARM64 -> "arm64-apple-watchos"
+    // Note: Kotlin/Native's watchosArm64 is arm64_32 (see targetTriple.watchos_arm64 in
+    // konan.properties), while watchosDeviceArm64 is arm64.
+    KonanTarget.WATCHOS_ARM64 -> "arm64_32-apple-watchos"
+    KonanTarget.WATCHOS_DEVICE_ARM64 -> "arm64-apple-watchos"
     else -> error("Unsupported target: $this")
 }

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/ConfigureSwiftDependencies.kt
@@ -393,8 +393,6 @@ private fun KonanTarget.getTriple(): String = when (this) {
     KonanTarget.TVOS_ARM64 -> "arm64-apple-tvos"
     // watchOS
     KonanTarget.WATCHOS_SIMULATOR_ARM64 -> "arm64-apple-watchos-simulator"
-    // Note: Kotlin/Native's watchosArm64 is arm64_32 (see targetTriple.watchos_arm64 in
-    // konan.properties), while watchosDeviceArm64 is arm64.
     KonanTarget.WATCHOS_ARM64 -> "arm64_32-apple-watchos"
     KonanTarget.WATCHOS_DEVICE_ARM64 -> "arm64-apple-watchos"
     else -> error("Unsupported target: $this")

--- a/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/GenerateDefFileTask.kt
+++ b/build-logic/convention/src/main/kotlin/com/revenuecat/purchases/kmp/buildlogic/swift/task/GenerateDefFileTask.kt
@@ -78,6 +78,9 @@ abstract class GenerateDefFileTask : DefaultTask() {
             linkerOpts.ios_x64 = -L$toolchain/lib/swift/iphonesimulator/
             linkerOpts.ios_arm64 = -L$toolchain/lib/swift/iphoneos/
             linkerOpts.ios_simulator_arm64 = -L$toolchain/lib/swift/iphonesimulator/
+            linkerOpts.watchos_arm64 = -L$toolchain/lib/swift/watchos/
+            linkerOpts.watchos_device_arm64 = -L$toolchain/lib/swift/watchos/
+            linkerOpts.watchos_simulator_arm64 = -L$toolchain/lib/swift/watchsimulator/
         """.trimIndent()
 
         val content = if (customDeclarations.isPresent) {


### PR DESCRIPTION
Part of #126. No module uses any of this yet, so existing targets build identically.

### Motivation

Groundwork in build-logic for adding watchOS targets in the follow-up PRs.

### Description

- Fixes the Swift target triple for `watchosArm64`: Kotlin/Native maps it to `arm64_32-apple-watchos` (32-bit `NSInteger`), not `arm64`. `watchosDeviceArm64` is the arm64 one.
- Adds watchOS linker opts to the generated cinterop def file (Swift runtime search paths).
- New `watchosTargets()` helper for build scripts.
- Generalizes the Apple opt-in wiring to all Apple source-set prefixes and adds `kotlinx.cinterop.UnsafeNumber` (needed once variable-width `NSInteger` bindings are commonized across 32/64-bit targets).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-logic only; no library modules enable watchOS yet. The main behavioral change is extra cinterop opt-ins on Apple source sets.
> 
> **Overview**
> Adds **build-logic groundwork** for watchOS without enabling it in any module yet.
> 
> Introduces `watchosTargets()` (`watchosArm64`, `watchosDeviceArm64`, `watchosSimulatorArm64`) for modules that opt in later.
> 
> Swift/cinterop wiring drops Intel `watchosX64`, uses the correct `arm64_32` triple for `watchosArm64` vs `arm64` for `watchosDeviceArm64`, and adds watchOS Swift runtime `linkerOpts` in generated `.def` files.
> 
> Apple language settings now apply `ExperimentalForeignApi` (and new `UnsafeNumber`) to all Apple source-set prefixes, not just iOS, so commonized 32/64-bit `NSInteger` bindings can compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 421085d34376de61497ca36052ca80d045cbfb30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->