### PR TITLE
Add watchOS support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,11 +42,6 @@ commands:
           command: sdkmanager "platform-tools"
 
   save-kotlin-native-compiler-to-cache:
-    parameters:
-      # CircleCI caches are write-once per key, so a different dependency set needs its own key.
-      key-suffix:
-        type: string
-        default: ""
     steps:
       - run:
           name: Get the Kotlin version
@@ -56,13 +51,9 @@ commands:
       - save_cache:
           name: Saving Kotlin/Native compiler to cache
           paths: [~/.konan]
-          key: konan<< parameters.key-suffix >>-{{ arch }}-{{ checksum "~/.kotlin_version" }}
+          key: konan-{{ arch }}-{{ checksum "~/.kotlin_version" }}
 
   restore-kotlin-native-compiler-from-cache:
-    parameters:
-      key-suffix:
-        type: string
-        default: ""
     steps:
       - run:
           name: Get the Kotlin version
@@ -71,7 +62,7 @@ commands:
       # containing it instead.
       - restore_cache:
           name: Restoring Kotlin/Native compiler from cache
-          key: konan<< parameters.key-suffix >>-{{ arch }}-{{ checksum "~/.kotlin_version" }}
+          key: konan-{{ arch }}-{{ checksum "~/.kotlin_version" }}
 
   save-gradle-user-home-directory-to-cache:
     steps:
@@ -195,16 +186,13 @@ jobs:
       - revenuecat/install-mise-tools:
           tools: java
       - restore-gradle-user-home-directory-from-cache
-      # Compiles both iOS and watchOS targets: restores both konan caches and saves neither,
-      # so each key keeps its single writer (the iOS jobs / build-and-test-watchos).
       - restore-kotlin-native-compiler-from-cache
-      - restore-kotlin-native-compiler-from-cache:
-          key-suffix: -watchos
       - attach-workspace-at-working-directory
       - run:
           name: Validate binary compatibility
           command: ./gradlew apiCheck
       - save-gradle-user-home-directory-to-cache
+      - save-kotlin-native-compiler-to-cache
 
   build-libraries-android:
     executor: android202409
@@ -263,8 +251,7 @@ jobs:
       - revenuecat/install-mise-tools:
           tools: java
       - restore-gradle-user-home-directory-from-cache
-      - restore-kotlin-native-compiler-from-cache:
-          key-suffix: -watchos
+      - restore-kotlin-native-compiler-from-cache
       - run:
           name: Build libraries and run tests for watchOS
           command: |
@@ -279,7 +266,6 @@ jobs:
               tasks+=(":either:compileKotlinWatchos$arch")
             done
             # The commonized (metadata) compilation only runs at publish time otherwise.
-            # Qualified per module to keep the sample apps out of this job.
             for module in core mappings kn-core models result either; do
               tasks+=(":$module:compileAppleMainKotlinMetadata")
               tasks+=(":$module:watchosSimulatorArm64Test")
@@ -290,8 +276,7 @@ jobs:
             tasks+=(":core:linkDebugTestWatchosDeviceArm64")
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
-      - save-kotlin-native-compiler-to-cache:
-          key-suffix: -watchos
+      - save-kotlin-native-compiler-to-cache
 
   build-sample-android:
     executor: android202409
@@ -456,11 +441,7 @@ jobs:
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - restore-gradle-user-home-directory-from-cache
-      # Compiles both iOS and watchOS targets: restores both konan caches and saves neither,
-      # so each key keeps its single writer (the iOS jobs / build-and-test-watchos).
       - restore-kotlin-native-compiler-from-cache
-      - restore-kotlin-native-compiler-from-cache:
-          key-suffix: -watchos
       - when:
           condition: << parameters.snapshot >>
           steps:
@@ -474,6 +455,7 @@ jobs:
                 name: "Publish release to Maven Central"
                 command: bundle exec fastlane publish_if_release
       - save-gradle-user-home-directory-to-cache
+      - save-kotlin-native-compiler-to-cache
 
   create-github-release:
     description: "Creates a GitHub release for the current version"
@@ -569,17 +551,14 @@ workflows:
             - revenuecat/install-mise-tools:
                 tools: java,ruby
             - restore-gradle-user-home-directory-from-cache
-            # Compiles both iOS and watchOS targets: restores both konan caches and saves
-            # neither, so each key keeps its single writer.
             - restore-kotlin-native-compiler-from-cache
-            - restore-kotlin-native-compiler-from-cache:
-                key-suffix: -watchos
             - revenuecat/install-gem-mac-dependencies:
                 cache-version: v1
             - run:
                 name: Regenerate API dumps
                 command: ./gradlew apiDump
             - save-gradle-user-home-directory-to-cache
+            - save-kotlin-native-compiler-to-cache
 
   # The release train starts with the release-train workflow, which is automatically 
   # triggered every week, but can also be triggered manually by passing the "action" 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ commands:
           command: sdkmanager "platform-tools"
 
   save-kotlin-native-compiler-to-cache:
+    parameters:
+      # Caches are write-once per key, so jobs downloading different K/N dependency sets (e.g.
+      # watchOS) must use their own key to avoid being shadowed by whichever job saves first.
+      key-suffix:
+        type: string
+        default: ""
     steps:
       - run:
           name: Get the Kotlin version
@@ -51,9 +57,13 @@ commands:
       - save_cache:
           name: Saving Kotlin/Native compiler to cache
           paths: [~/.konan]
-          key: konan-{{ arch }}-{{ checksum "~/.kotlin_version" }}
+          key: konan<< parameters.key-suffix >>-{{ arch }}-{{ checksum "~/.kotlin_version" }}
 
   restore-kotlin-native-compiler-from-cache:
+    parameters:
+      key-suffix:
+        type: string
+        default: ""
     steps:
       - run:
           name: Get the Kotlin version
@@ -62,7 +72,7 @@ commands:
       # containing it instead.
       - restore_cache:
           name: Restoring Kotlin/Native compiler from cache
-          key: konan-{{ arch }}-{{ checksum "~/.kotlin_version" }}
+          key: konan<< parameters.key-suffix >>-{{ arch }}-{{ checksum "~/.kotlin_version" }}
 
   save-gradle-user-home-directory-to-cache:
     steps:
@@ -186,13 +196,16 @@ jobs:
       - revenuecat/install-mise-tools:
           tools: java
       - restore-gradle-user-home-directory-from-cache
+      # Compiles both iOS and watchOS targets: restores both konan caches and saves neither,
+      # so each key keeps its single writer (the iOS jobs / build-and-test-watchos).
       - restore-kotlin-native-compiler-from-cache
+      - restore-kotlin-native-compiler-from-cache:
+          key-suffix: -watchos
       - attach-workspace-at-working-directory
       - run:
           name: Validate binary compatibility
           command: ./gradlew apiCheck
       - save-gradle-user-home-directory-to-cache
-      - save-kotlin-native-compiler-to-cache
 
   build-libraries-android:
     executor: android202409
@@ -240,6 +253,45 @@ jobs:
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache
       - save-incremental-gradle-build-to-workspace
+
+  # Self-contained on purpose: no workspace persistence or attachment, so it can run in
+  # parallel to the iOS chain without workspace conflicts.
+  build-and-test-watchos:
+    executor: xcode16
+    steps:
+      - checkout
+      - checkout-submodule
+      - revenuecat/install-mise-tools:
+          tools: java
+      - restore-gradle-user-home-directory-from-cache
+      - restore-kotlin-native-compiler-from-cache:
+          key-suffix: -watchos
+      - run:
+          name: Build libraries and run tests for watchOS
+          command: |
+            tasks=()
+            for module in core result; do
+              for arch in Arm64 DeviceArm64 SimulatorArm64; do
+                tasks+=(":$module:compileKotlinWatchos$arch")
+              done
+            done
+            # either skips DeviceArm64: arrow-core doesn't publish it.
+            for arch in Arm64 SimulatorArm64; do
+              tasks+=(":either:compileKotlinWatchos$arch")
+            done
+            # The commonized (metadata) compilation only runs at publish time otherwise.
+            # Qualified per module to keep the sample apps out of this job.
+            for module in core mappings kn-core models result either; do
+              tasks+=(":$module:compileAppleMainKotlinMetadata")
+              tasks+=(":$module:watchosSimulatorArm64Test")
+            done
+            # Links an arm64_32 binary: compile alone would miss bad Swift-runtime linker
+            # opts or missing symbols in the static libs, and no other job links for device.
+            tasks+=(":core:linkDebugTestWatchosArm64")
+            ./gradlew "${tasks[@]}"
+      - save-gradle-user-home-directory-to-cache
+      - save-kotlin-native-compiler-to-cache:
+          key-suffix: -watchos
 
   build-sample-android:
     executor: android202409
@@ -404,7 +456,11 @@ jobs:
       - revenuecat/install-gem-mac-dependencies:
           cache-version: v1
       - restore-gradle-user-home-directory-from-cache
+      # Compiles both iOS and watchOS targets: restores both konan caches and saves neither,
+      # so each key keeps its single writer (the iOS jobs / build-and-test-watchos).
       - restore-kotlin-native-compiler-from-cache
+      - restore-kotlin-native-compiler-from-cache:
+          key-suffix: -watchos
       - when:
           condition: << parameters.snapshot >>
           steps:
@@ -418,7 +474,6 @@ jobs:
                 name: "Publish release to Maven Central"
                 command: bundle exec fastlane publish_if_release
       - save-gradle-user-home-directory-to-cache
-      - save-kotlin-native-compiler-to-cache
 
   create-github-release:
     description: "Creates a GitHub release for the current version"
@@ -459,6 +514,7 @@ workflows:
       - unit-tests-build-logic
       - build-libraries-android
       - build-libraries-ios
+      - build-and-test-watchos
       - build-sample-android:
           requires: [build-libraries-android]
       - build-sample-ios:
@@ -502,8 +558,8 @@ workflows:
           outputs: |
             PurchasesErrorCode.kt:models/src/commonMain/kotlin/generated/com/revenuecat/purchases/kmp/models/PurchasesErrorCode.kt
             errors.android.kt:mappings/src/androidMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.android.kt
-            errors.ios.kt:mappings/src/appleMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.ios.kt
-          commit_paths: "models/src/commonMain/kotlin/generated/com/revenuecat/purchases/kmp/models/PurchasesErrorCode.kt,mappings/src/androidMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.android.kt,mappings/src/appleMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.ios.kt,models/api/models.api,models/api/models.klib.api"
+            errors.apple.kt:mappings/src/appleMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.apple.kt
+          commit_paths: "models/src/commonMain/kotlin/generated/com/revenuecat/purchases/kmp/models/PurchasesErrorCode.kt,mappings/src/androidMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.android.kt,mappings/src/appleMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.apple.kt,models/api/models.api,models/api/models.klib.api"
           context:
             - git-user-ops
             - github-bot-public
@@ -513,14 +569,17 @@ workflows:
             - revenuecat/install-mise-tools:
                 tools: java,ruby
             - restore-gradle-user-home-directory-from-cache
+            # Compiles both iOS and watchOS targets: restores both konan caches and saves
+            # neither, so each key keeps its single writer.
             - restore-kotlin-native-compiler-from-cache
+            - restore-kotlin-native-compiler-from-cache:
+                key-suffix: -watchos
             - revenuecat/install-gem-mac-dependencies:
                 cache-version: v1
             - run:
                 name: Regenerate API dumps
                 command: ./gradlew apiDump
             - save-gradle-user-home-directory-to-cache
-            - save-kotlin-native-compiler-to-cache
 
   # The release train starts with the release-train workflow, which is automatically 
   # triggered every week, but can also be triggered manually by passing the "action" 
@@ -556,6 +615,7 @@ workflows:
       - unit-tests-build-logic
       - build-libraries-android
       - build-libraries-ios
+      - build-and-test-watchos
       - build-sample-android:
           requires: [build-libraries-android]
       - build-sample-ios:
@@ -577,6 +637,7 @@ workflows:
           requires:
             - detekt
             - unit-tests-build-logic
+            - build-and-test-watchos
             - build-sample-android
             - build-sample-ios
             - public-api-tests-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,7 @@ commands:
 
   save-kotlin-native-compiler-to-cache:
     parameters:
-      # Caches are write-once per key, so jobs downloading different K/N dependency sets (e.g.
-      # watchOS) must use their own key to avoid being shadowed by whichever job saves first.
+      # CircleCI caches are write-once per key, so a different dependency set needs its own key.
       key-suffix:
         type: string
         default: ""
@@ -285,9 +284,10 @@ jobs:
               tasks+=(":$module:compileAppleMainKotlinMetadata")
               tasks+=(":$module:watchosSimulatorArm64Test")
             done
-            # Links an arm64_32 binary: compile alone would miss bad Swift-runtime linker
+            # Links both device slices: compile alone would miss bad Swift-runtime linker
             # opts or missing symbols in the static libs, and no other job links for device.
             tasks+=(":core:linkDebugTestWatchosArm64")
+            tasks+=(":core:linkDebugTestWatchosDeviceArm64")
             ./gradlew "${tasks[@]}"
       - save-gradle-user-home-directory-to-cache
       - save-kotlin-native-compiler-to-cache:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ purchases-kmp/
 │   └── src/
 │       ├── commonMain/       # Shared Kotlin code
 │       ├── androidMain/      # Android-specific implementations
-│       └── appleMain/        # Apple-specific implementations (Swift interop)
+│       └── appleMain/        # Apple-specific implementations (Swift interop), split further into iosMain/watchosMain where needed
 ├── models/                   # Shared data models and domain objects
 ├── mappings/                 # Platform-specific mappings
 ├── revenuecatui/             # Jetpack Compose UI components for paywalls
@@ -121,7 +121,7 @@ module/src/
 ├── commonTest/       # Shared tests
 ├── androidMain/      # Android-specific implementations
 ├── androidUnitTest/  # Android unit tests
-├── appleMain/        # Apple-specific implementations
+├── appleMain/        # Apple-specific implementations (iOS + watchOS)
 └── appleTest/        # Apple platform tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ our [migration guide](./migrations/KobanKat-MIGRATION.md)
 | --- | --- |
 ✅ | Server-side receipt validation
 ➡️ | [Webhooks](https://docs.revenuecat.com/docs/webhooks) - enhanced server-to-server communication with events for purchases, renewals, cancellations, and more
-📱 | Android and iOS support
+📱 | Android, iOS and watchOS support
 🎯 | Subscription status tracking - know whether a user is subscribed whether they're on iOS, Android or web
 📊 | Analytics - automatic calculation of metrics like conversion, mrr, and churn
 📝 | [Online documentation](https://docs.revenuecat.com/docs) and [SDK Reference](https://revenuecat.github.io/purchases-kmp/) up to date
@@ -66,7 +66,8 @@ This codelab is a step-by-step tutorial designed to help you learn and master th
 - Java 8+
 - Kotlin 2.3.20+
 - Android 6.0+ (API level 23+)
-- iOS 13.0+ 
+- iOS 13.0+
+- watchOS 7.0+ (9.0+ on `watchosDeviceArm64`). Note: Paywalls and Customer Center (the `-ui` artifact) are iOS only.
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-kmp/).

--- a/core/api/core.klib.api
+++ b/core/api/core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
+import com.revenuecat.purchases.kmp.buildlogic.watchosTargets
 
 plugins {
     id("revenuecat-library")
@@ -10,6 +11,8 @@ revenueCat {
 }
 
 kotlin {
+    watchosTargets()
+
     sourceSets {
         commonMain.dependencies {
             api(projects.models)

--- a/core/src/appleMain/kotlin/com/revenuecat/purchases/kmp/AdTracker.apple.kt
+++ b/core/src/appleMain/kotlin/com/revenuecat/purchases/kmp/AdTracker.apple.kt
@@ -16,8 +16,8 @@ public actual class AdTracker internal constructor(
     private val iosAdTracker: RCAdTracker
 ) {
     public actual fun trackAdDisplayed(data: AdDisplayedData) {
-        if (!AppleApiAvailability().isAdTrackingAPIAvailable()) {
-            Purchases.logHandler.w("Purchases", "Ad tracking requires iOS 15.0+. Current API is unavailable.")
+        if (!appleApiAvailability.isAdTrackingAPIAvailable()) {
+            Purchases.logHandler.w("Purchases", AD_TRACKING_UNAVAILABLE_MESSAGE)
             return
         }
 
@@ -25,8 +25,8 @@ public actual class AdTracker internal constructor(
     }
 
     public actual fun trackAdOpened(data: AdOpenedData) {
-        if (!AppleApiAvailability().isAdTrackingAPIAvailable()) {
-            Purchases.logHandler.w("Purchases", "Ad tracking requires iOS 15.0+. Current API is unavailable.")
+        if (!appleApiAvailability.isAdTrackingAPIAvailable()) {
+            Purchases.logHandler.w("Purchases", AD_TRACKING_UNAVAILABLE_MESSAGE)
             return
         }
 
@@ -34,8 +34,8 @@ public actual class AdTracker internal constructor(
     }
 
     public actual fun trackAdRevenue(data: AdRevenueData) {
-        if (!AppleApiAvailability().isAdTrackingAPIAvailable()) {
-            Purchases.logHandler.w("Purchases", "Ad tracking requires iOS 15.0+. Current API is unavailable.")
+        if (!appleApiAvailability.isAdTrackingAPIAvailable()) {
+            Purchases.logHandler.w("Purchases", AD_TRACKING_UNAVAILABLE_MESSAGE)
             return
         }
 
@@ -43,8 +43,8 @@ public actual class AdTracker internal constructor(
     }
 
     public actual fun trackAdLoaded(data: AdLoadedData) {
-        if (!AppleApiAvailability().isAdTrackingAPIAvailable()) {
-            Purchases.logHandler.w("Purchases", "Ad tracking requires iOS 15.0+. Current API is unavailable.")
+        if (!appleApiAvailability.isAdTrackingAPIAvailable()) {
+            Purchases.logHandler.w("Purchases", AD_TRACKING_UNAVAILABLE_MESSAGE)
             return
         }
 
@@ -52,11 +52,16 @@ public actual class AdTracker internal constructor(
     }
 
     public actual fun trackAdFailedToLoad(data: AdFailedToLoadData) {
-        if (!AppleApiAvailability().isAdTrackingAPIAvailable()) {
-            Purchases.logHandler.w("Purchases", "Ad tracking requires iOS 15.0+. Current API is unavailable.")
+        if (!appleApiAvailability.isAdTrackingAPIAvailable()) {
+            Purchases.logHandler.w("Purchases", AD_TRACKING_UNAVAILABLE_MESSAGE)
             return
         }
 
         iosAdTracker.trackAdFailedToLoad(data.toIos())
     }
 }
+
+private val appleApiAvailability = AppleApiAvailability()
+
+private const val AD_TRACKING_UNAVAILABLE_MESSAGE =
+    "Ad tracking requires iOS 15.0+ or watchOS 8.0+. Current API is unavailable."

--- a/core/src/appleMain/kotlin/com/revenuecat/purchases/kmp/Purchases.apple.kt
+++ b/core/src/appleMain/kotlin/com/revenuecat/purchases/kmp/Purchases.apple.kt
@@ -12,7 +12,6 @@ import com.revenuecat.purchases.kmp.mappings.toIosPackage
 import com.revenuecat.purchases.kmp.mappings.toIosPromotionalOffer
 import com.revenuecat.purchases.kmp.mappings.toIosPurchasesAreCompletedBy
 import com.revenuecat.purchases.kmp.mappings.toIosStoreKitVersion
-import com.revenuecat.purchases.kmp.mappings.toIosStoreMessageTypes
 import com.revenuecat.purchases.kmp.mappings.toIosStoreProduct
 import com.revenuecat.purchases.kmp.mappings.toIosStoreProductDiscount
 import com.revenuecat.purchases.kmp.mappings.toIosWinBackOffer
@@ -74,7 +73,6 @@ import com.revenuecat.purchases.kn.core.setAirbridgeDeviceID
 import com.revenuecat.purchases.kn.core.setAirshipChannelID
 import com.revenuecat.purchases.kn.core.setOnesignalUserID
 import com.revenuecat.purchases.kn.core.setPostHogUserID
-import com.revenuecat.purchases.kn.core.showStoreMessagesForTypes
 import com.revenuecat.purchases.kn.core.trackCustomPaywallImpression
 import com.revenuecat.purchases.kn.core.RCDangerousSettings as IosDangerousSettings
 import com.revenuecat.purchases.kn.core.RCPurchases as IosPurchases
@@ -393,11 +391,11 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         // API availability checks must be performed here at the KMP level, since the KMP/ObjC/Swift
         // interoperability drops the @available(osVersion) requirements, and you can technically
         // call functions with an @available from any OS version in KMP
-        if (!AppleApiAvailability().isWinBackOfferAPIAvailable()) {
+        if (!appleApiAvailability.isWinBackOfferAPIAvailable()) {
             onError(
                 PurchasesError(
                     PurchasesErrorCode.UnsupportedError,
-                    underlyingErrorMessage = "getEligibleWinBackOffersForProduct is only available on iOS 18.0+"
+                    underlyingErrorMessage = "getEligibleWinBackOffersForProduct $WIN_BACK_UNAVAILABLE_SUFFIX"
                 )
             )
             return
@@ -439,11 +437,11 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         // API availability checks must be performed here at the KMP level, since the KMP/ObjC/Swift
         // interoperability drops the @available(osVersion) requirements, and you can technically
         // call functions with an @available from any OS version in KMP
-        if (!AppleApiAvailability().isWinBackOfferAPIAvailable()) {
+        if (!appleApiAvailability.isWinBackOfferAPIAvailable()) {
             onError(
                 PurchasesError(
                     PurchasesErrorCode.UnsupportedError,
-                    underlyingErrorMessage = "getEligibleWinBackOffersForPackage is only available on iOS 18.0+"
+                    underlyingErrorMessage = "getEligibleWinBackOffersForPackage $WIN_BACK_UNAVAILABLE_SUFFIX"
                 )
             )
             return
@@ -486,11 +484,11 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         // API availability checks must be performed here at the KMP level, since the KMP/ObjC/Swift
         // interoperability drops the @available(osVersion) requirements, and you can technically
         // call functions with an @available from any OS version in KMP
-        if (!AppleApiAvailability().isWinBackOfferAPIAvailable()) {
+        if (!appleApiAvailability.isWinBackOfferAPIAvailable()) {
             onError(
                 PurchasesError(
                     PurchasesErrorCode.UnsupportedError,
-                    underlyingErrorMessage = "purchase(product:winBackOffer:onError:onSuccess:) is only available on iOS 18.0+"
+                    underlyingErrorMessage = "purchase(product:winBackOffer:onError:onSuccess:) $WIN_BACK_UNAVAILABLE_SUFFIX"
                 ),
                 false
             )
@@ -543,11 +541,11 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         // API availability checks must be performed here at the KMP level, since the KMP/ObjC/Swift
         // interoperability drops the @available(osVersion) requirements, and you can technically
         // call functions with an @available from any OS version in KMP
-        if (!AppleApiAvailability().isWinBackOfferAPIAvailable()) {
+        if (!appleApiAvailability.isWinBackOfferAPIAvailable()) {
             onError(
                 PurchasesError(
                     PurchasesErrorCode.UnsupportedError,
-                    underlyingErrorMessage = "purchase(packageToPurchase:winBackOffer:onError:onSuccess:) is only available on iOS 18.0+"
+                    underlyingErrorMessage = "purchase(packageToPurchase:winBackOffer:onError:onSuccess:) $WIN_BACK_UNAVAILABLE_SUFFIX"
                 ),
                 false
             )
@@ -629,7 +627,7 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
     public actual fun showInAppMessagesIfNeeded(
         messageTypes: List<StoreMessageType>,
     ) {
-        iosPurchases.showStoreMessagesForTypes(messageTypes.toIosStoreMessageTypes()) {}
+        iosPurchases.showStoreMessagesIfAvailable(messageTypes)
     }
 
     public actual fun invalidateCustomerInfoCache(): Unit =
@@ -711,21 +709,16 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         iosPurchases.setCreative(creative)
 
     public actual fun presentCodeRedemptionSheet() {
-        if (AppleApiAvailability().isCodeRedemptionSheetAPIAvailable())
-            iosPurchases.presentCodeRedemptionSheet()
-        else logHandler.d(
-            tag = "Purchases",
-            msg = "`presentCodeRedemptionSheet()` is only available on iOS 14.0 and up."
-        )
+        iosPurchases.presentCodeRedemptionSheetIfAvailable()
     }
 
     public actual fun enableAdServicesAttributionTokenCollection() {
-        if (AppleApiAvailability().isEnableAdServicesAttributionTokenCollectionAPIAvailable())
+        if (appleApiAvailability.isEnableAdServicesAttributionTokenCollectionAPIAvailable())
             iosPurchases.attribution().enableAdServicesAttributionTokenCollection()
         else logHandler.d(
             tag = "Purchases",
             msg = "`enableAdServicesAttributionTokenCollection()` is only available on iOS 14.3 " +
-                    "and up."
+                    "and up. It is not available on watchOS."
         )
     }
 
@@ -802,10 +795,10 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
     public actual fun trackCustomPaywallImpression(
         params: CustomPaywallImpressionParams,
     ) {
-        if (!AppleApiAvailability().isCustomPaywallTrackingAPIAvailable()) {
+        if (!appleApiAvailability.isCustomPaywallTrackingAPIAvailable()) {
             logHandler.w(
                 "Purchases",
-                "Custom paywall tracking requires iOS 15.0+. Current API is unavailable."
+                "Custom paywall tracking requires iOS 15.0+ or watchOS 8.0+. Current API is unavailable."
             )
             return
         }
@@ -848,3 +841,22 @@ public actual class Purchases private constructor(private val iosPurchases: IosP
         )
     }
 }
+
+/**
+ * Presents the code redemption sheet where available (iOS 14.0+), or logs otherwise. The native
+ * API does not exist on watchOS, so the iOS call must live in an iOS-only source set: cinterop
+ * bindings shared across Apple targets only contain APIs available on all of them.
+ */
+internal expect fun IosPurchases.presentCodeRedemptionSheetIfAvailable()
+
+/**
+ * iOS: shows store messages of the given types (native API, iOS 16.0+). watchOS: logs and does
+ * nothing, the native API does not exist there, which is why the iOS call must live in an
+ * iOS-only source set: cinterop bindings shared across Apple targets only contain APIs
+ * available on all of them.
+ */
+internal expect fun IosPurchases.showStoreMessagesIfAvailable(messageTypes: List<StoreMessageType>)
+
+private val appleApiAvailability = AppleApiAvailability()
+
+private const val WIN_BACK_UNAVAILABLE_SUFFIX = "is only available on iOS 18.0+ or watchOS 11.0+"

--- a/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/Purchases.kt
+++ b/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/Purchases.kt
@@ -462,7 +462,7 @@ public expect class Purchases {
     /**
      * Fetches the win-back offers that a subscriber is eligible for on a given product.
      *
-     * iOS only. Requires iOS 18.0+ and StoreKit 2 and emits an error if these requirements aren't
+     * Apple platforms only. Requires iOS 18.0+ or watchOS 11.0+ and StoreKit 2 and emits an error if these requirements aren't
      * met.
      *
      * @param storeProduct: The product to check for eligible win-back offers on.
@@ -480,7 +480,7 @@ public expect class Purchases {
     /**
      * Fetches the win-back offers that a subscriber is eligible for on a given package.
      *
-     * iOS only. Requires iOS 18.0+ and StoreKit 2 and emits an error if these requirements aren't
+     * Apple platforms only. Requires iOS 18.0+ or watchOS 11.0+ and StoreKit 2 and emits an error if these requirements aren't
      * met.
      *
      * @param packageToCheck: The package to check for eligible win-back offers on.
@@ -499,7 +499,7 @@ public expect class Purchases {
      * Purchases a product with a given win-back offer. If you are using the Offerings system, use the
      * overload with a [Package] parameter instead.
      *
-     * iOS only. Requires iOS 18.0+ and StoreKit 2 and emits an error if these requirements aren't
+     * Apple platforms only. Requires iOS 18.0+ or watchOS 11.0+ and StoreKit 2 and emits an error if these requirements aren't
      * met.
      *
      * @param storeProduct: The product to purchase
@@ -521,7 +521,7 @@ public expect class Purchases {
     /**
      * Purchases a package with a given win-back offer.
      *
-     * iOS only. Requires iOS 18.0+ and StoreKit 2 and emits an error if these requirements aren't
+     * Apple platforms only. Requires iOS 18.0+ or watchOS 11.0+ and StoreKit 2 and emits an error if these requirements aren't
      * met.
      *
      * @param packageToPurchase: The package to purchase
@@ -577,7 +577,7 @@ public expect class Purchases {
     )
 
     /**
-     * Google Play and App Store only, no-op for Amazon.
+     * Google Play and App Store only, no-op for Amazon and watchOS.
      * Displays the specified in-app message types to the user as a snackbar if there are any
      * available to be shown.
      * If [PurchasesConfiguration.showInAppMessagesAutomatically] is enabled, this will be done
@@ -808,7 +808,7 @@ public expect class Purchases {
      * Refer to https://docs.revenuecat.com/docs/ios-subscription-offers#offer-codes
      * for more information on how to configure and use offer codes.
      *
-     * On Android, this is a no-op.
+     * On Android and watchOS, this is a no-op.
      */
     public fun presentCodeRedemptionSheet()
 

--- a/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/Purchases.kt
+++ b/core/src/commonMain/kotlin/com/revenuecat/purchases/kmp/Purchases.kt
@@ -816,6 +816,8 @@ public expect class Purchases {
      * Enable automatic collection of Apple Search Ad attribution on iOS. Disabled by default.
      *
      * **Note:** this is only available on iOS 14.3 and up.
+     *
+     * On Android and watchOS, this is a no-op.
      */
     public fun enableAdServicesAttributionTokenCollection()
 

--- a/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
+++ b/core/src/iosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.ios.kt
@@ -1,0 +1,22 @@
+package com.revenuecat.purchases.kmp
+
+import com.revenuecat.purchases.kmp.mappings.toIosStoreMessageTypes
+import com.revenuecat.purchases.kmp.models.StoreMessageType
+import com.revenuecat.purchases.kn.core.additional.AppleApiAvailability
+import com.revenuecat.purchases.kn.core.showStoreMessagesForTypes
+import com.revenuecat.purchases.kn.core.RCPurchases as IosPurchases
+
+internal actual fun IosPurchases.presentCodeRedemptionSheetIfAvailable() {
+    if (AppleApiAvailability().isCodeRedemptionSheetAPIAvailable())
+        presentCodeRedemptionSheet()
+    else Purchases.logHandler.d(
+        tag = "Purchases",
+        msg = "`presentCodeRedemptionSheet()` is only available on iOS 14.0 and up."
+    )
+}
+
+internal actual fun IosPurchases.showStoreMessagesIfAvailable(
+    messageTypes: List<StoreMessageType>,
+) {
+    showStoreMessagesForTypes(messageTypes.toIosStoreMessageTypes()) {}
+}

--- a/core/src/watchosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.watchos.kt
+++ b/core/src/watchosMain/kotlin/com/revenuecat/purchases/kmp/Purchases.watchos.kt
@@ -1,0 +1,20 @@
+package com.revenuecat.purchases.kmp
+
+import com.revenuecat.purchases.kmp.models.StoreMessageType
+import com.revenuecat.purchases.kn.core.RCPurchases as IosPurchases
+
+internal actual fun IosPurchases.presentCodeRedemptionSheetIfAvailable() {
+    Purchases.logHandler.d(
+        tag = "Purchases",
+        msg = "`presentCodeRedemptionSheet()` is not available on watchOS."
+    )
+}
+
+internal actual fun IosPurchases.showStoreMessagesIfAvailable(
+    messageTypes: List<StoreMessageType>,
+) {
+    Purchases.logHandler.d(
+        tag = "Purchases",
+        msg = "`showInAppMessagesIfNeeded()` is not available on watchOS."
+    )
+}

--- a/either/api/either.klib.api
+++ b/either/api/either.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/either/build.gradle.kts
+++ b/either/build.gradle.kts
@@ -7,6 +7,10 @@ revenueCat {
 }
 
 kotlin {
+    // Not using watchosTargets() because arrow-core does not publish watchosDeviceArm64.
+    watchosArm64()
+    watchosSimulatorArm64()
+
     sourceSets {
         commonMain.dependencies {
             api(libs.arrow.core)

--- a/kn-core/api/kn-core.klib.api
+++ b/kn-core/api/kn-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/kn-core/build.gradle.kts
+++ b/kn-core/build.gradle.kts
@@ -1,11 +1,14 @@
 import com.revenuecat.purchases.kmp.buildlogic.swift.model.SwiftSettings
 import com.revenuecat.purchases.kmp.buildlogic.swift.swiftPackage
+import com.revenuecat.purchases.kmp.buildlogic.watchosTargets
 
 plugins {
     id("revenuecat-library")
 }
 
 kotlin {
+    watchosTargets()
+
     sourceSets {
         appleMain.dependencies {
             swiftPackage(

--- a/mappings/build.gradle.kts
+++ b/mappings/build.gradle.kts
@@ -1,8 +1,12 @@
+import com.revenuecat.purchases.kmp.buildlogic.watchosTargets
+
 plugins {
     id("revenuecat-library")
 }
 
 kotlin {
+    watchosTargets()
+
     sourceSets {
         commonMain.dependencies {
             api(projects.models)
@@ -12,6 +16,10 @@ kotlin {
         }
         appleMain.dependencies {
             implementation(projects.knCore)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test.annotations)
+            implementation(libs.kotlin.test.assertions)
         }
         androidUnitTest.dependencies {
             implementation(libs.kotlin.test.junit)

--- a/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.apple.kt
+++ b/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.apple.kt
@@ -9,10 +9,8 @@ import com.revenuecat.purchases.kmp.models.AdMediatorName
 import com.revenuecat.purchases.kmp.models.AdOpenedData
 import com.revenuecat.purchases.kmp.models.AdRevenueData
 import com.revenuecat.purchases.kmp.models.AdRevenuePrecision
-import kotlinx.cinterop.convert
+import com.revenuecat.purchases.kmp.mappings.ktx.toNSInteger
 import platform.Foundation.NSNumber
-import platform.darwin.NSIntegerMax
-import platform.darwin.NSIntegerMin
 import com.revenuecat.purchases.kn.core.RCAdDisplayed
 import com.revenuecat.purchases.kn.core.RCAdFailedToLoad
 import com.revenuecat.purchases.kn.core.RCAdFormat
@@ -67,12 +65,7 @@ public fun AdRevenueData.toIos(): RCAdRevenue {
         placement = placement,
         adUnitId = adUnitId,
         impressionId = impressionId,
-        // The native type is NSInteger, which is 32 bits on watchosArm64 (arm64_32). Clamping
-        // to the platform NSInteger range before convert() turns a silent sign-wrap into a
-        // bounded value there; it is a no-op on 64-bit targets.
-        revenueMicros = revenueMicros
-            .coerceIn(NSIntegerMin.toLong(), NSIntegerMax.toLong())
-            .convert(),
+        revenueMicros = revenueMicros.toNSInteger(),
         currency = currency,
         precision = precision.toIos(),
     )

--- a/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.apple.kt
+++ b/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.apple.kt
@@ -9,7 +9,10 @@ import com.revenuecat.purchases.kmp.models.AdMediatorName
 import com.revenuecat.purchases.kmp.models.AdOpenedData
 import com.revenuecat.purchases.kmp.models.AdRevenueData
 import com.revenuecat.purchases.kmp.models.AdRevenuePrecision
+import kotlinx.cinterop.convert
 import platform.Foundation.NSNumber
+import platform.darwin.NSIntegerMax
+import platform.darwin.NSIntegerMin
 import com.revenuecat.purchases.kn.core.RCAdDisplayed
 import com.revenuecat.purchases.kn.core.RCAdFailedToLoad
 import com.revenuecat.purchases.kn.core.RCAdFormat
@@ -64,7 +67,12 @@ public fun AdRevenueData.toIos(): RCAdRevenue {
         placement = placement,
         adUnitId = adUnitId,
         impressionId = impressionId,
-        revenueMicros = revenueMicros,
+        // The native type is NSInteger, which is 32 bits on watchosArm64 (arm64_32). Clamping
+        // to the platform NSInteger range before convert() turns a silent sign-wrap into a
+        // bounded value there; it is a no-op on 64-bit targets.
+        revenueMicros = revenueMicros
+            .coerceIn(NSIntegerMin.toLong(), NSIntegerMax.toLong())
+            .convert(),
         currency = currency,
         precision = precision.toIos(),
     )
@@ -89,6 +97,6 @@ public fun AdFailedToLoadData.toIos(): RCAdFailedToLoad {
         adFormat = adFormat.toIos(),
         placement = placement,
         adUnitId = adUnitId,
-        mediatorErrorCode = mediatorErrorCode?.let { NSNumber(it) },
+        mediatorErrorCode = mediatorErrorCode?.let { NSNumber(int = it) },
     )
 }

--- a/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.apple.kt
+++ b/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/Price.apple.kt
@@ -9,7 +9,7 @@ import com.revenuecat.purchases.kn.core.price
 internal fun RCStoreProduct.toPrice(): Price =
     Price(
         formatted = localizedPriceString(),
-        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longValue,
+        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longLongValue,
         currencyCode = currencyCodeOrUsd(),
     )
 
@@ -19,7 +19,7 @@ internal fun RCStoreProduct.currencyCodeOrUsd(): String =
 internal fun RCStoreProductDiscount.toPrice(): Price =
     Price(
         formatted = localizedPriceString(),
-        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longValue,
+        amountMicros = price().decimalNumberByMultiplyingByPowerOf10(6).longLongValue,
         currencyCode = currencyCodeOrUsd(),
     )
 
@@ -37,7 +37,7 @@ internal fun priceOrNull(
 ): Price? = priceOrNull(
     currencyCode = currencyCode,
     formatted = formatted,
-    amountMicros = amountDecimal?.decimalNumberByMultiplyingByPowerOf10(6)?.longValue
+    amountMicros = amountDecimal?.decimalNumberByMultiplyingByPowerOf10(6)?.longLongValue
 )
 
 /**

--- a/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProductDiscount.apple.kt
+++ b/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/StoreProductDiscount.apple.kt
@@ -16,7 +16,8 @@ private class IosStoreProductDiscount(
     val wrapped: NativeIosStoreProductDiscount,
 ): StoreProductDiscount {
     override val price: Price = wrapped.toPrice()
-    override val numberOfPeriods: Long = wrapped.numberOfPeriods()
+    // toLong() because the native type is NSInteger, which is 32 bits on watchosArm64 (arm64_32).
+    override val numberOfPeriods: Long = wrapped.numberOfPeriods().toLong()
     override val offerIdentifier: String? = wrapped.offerIdentifier()
     override val paymentMode: DiscountPaymentMode = wrapped.paymentMode().toDiscountPaymentMode()
     override val subscriptionPeriod: Period = wrapped.subscriptionPeriod().toPeriod()

--- a/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/ktx/NSInteger.kt
+++ b/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/ktx/NSInteger.kt
@@ -1,0 +1,13 @@
+package com.revenuecat.purchases.kmp.mappings.ktx
+
+import kotlinx.cinterop.convert
+import platform.darwin.NSInteger
+import platform.darwin.NSIntegerMax
+import platform.darwin.NSIntegerMin
+
+/**
+ * Converts to the platform's `NSInteger`, which is 32 bits on watchosArm64 (arm64_32). Values
+ * outside that range are clamped, as `convert()` alone would silently wrap them.
+ */
+internal fun Long.toNSInteger(): NSInteger =
+    coerceIn(NSIntegerMin.toLong(), NSIntegerMax.toLong()).convert()

--- a/mappings/src/appleMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.apple.kt
+++ b/mappings/src/appleMain/kotlin/generated/com/revenuecat/purchases/kmp/mappings/errors.apple.kt
@@ -9,7 +9,7 @@ import platform.Foundation.NSError
 
 public fun NSError.toPurchasesErrorOrThrow(): PurchasesError =
     PurchasesError(
-        code = code().toPurchasesErrorCode(),
+        code = code().toLong().toPurchasesErrorCode(),
         underlyingErrorMessage = localizedDescription(),
     )
 

--- a/mappings/src/appleTest/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypesTest.kt
+++ b/mappings/src/appleTest/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypesTest.kt
@@ -1,0 +1,44 @@
+package com.revenuecat.purchases.kmp.mappings
+
+import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.models.AdFormat
+import com.revenuecat.purchases.kmp.models.AdMediatorName
+import com.revenuecat.purchases.kmp.models.AdRevenueData
+import com.revenuecat.purchases.kmp.models.AdRevenuePrecision
+import platform.darwin.NSIntegerMax
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalRevenueCatApi::class)
+class AdEventTypesTest {
+
+    // Regression test: revenueMicros used to be clamped to the 32-bit Int range on all Apple
+    // targets, corrupting large revenues (common in low-unit currencies) on 64-bit platforms.
+    @Test
+    fun `revenueMicros preserves values beyond 32 bits where NSInteger is 64-bit`() {
+        val largeRevenueMicros = 10_000_000_000L
+        if (NSIntegerMax.toLong() < largeRevenueMicros) return // arm64_32: clamping is expected
+
+        val mapped = adRevenueData(revenueMicros = largeRevenueMicros).toIos()
+
+        assertEquals(largeRevenueMicros, mapped.revenueMicros().toLong())
+    }
+
+    @Test
+    fun `revenueMicros never exceeds the platform NSInteger range`() {
+        val mapped = adRevenueData(revenueMicros = Long.MAX_VALUE).toIos()
+
+        assertEquals(NSIntegerMax.toLong(), mapped.revenueMicros().toLong())
+    }
+
+    private fun adRevenueData(revenueMicros: Long) = AdRevenueData(
+        mediatorName = AdMediatorName.APP_LOVIN,
+        adFormat = AdFormat.BANNER,
+        placement = null,
+        adUnitId = "adUnitId",
+        impressionId = "impressionId",
+        revenueMicros = revenueMicros,
+        currency = "USD",
+        precision = AdRevenuePrecision.EXACT,
+    )
+}

--- a/mappings/src/appleTest/kotlin/com/revenuecat/purchases/kmp/mappings/ErrorsTest.kt
+++ b/mappings/src/appleTest/kotlin/com/revenuecat/purchases/kmp/mappings/ErrorsTest.kt
@@ -1,0 +1,42 @@
+package com.revenuecat.purchases.kmp.mappings
+
+import com.revenuecat.purchases.kmp.models.PurchasesErrorCode
+import kotlinx.cinterop.convert
+import platform.Foundation.NSError
+import platform.Foundation.NSLocalizedDescriptionKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ErrorsTest {
+
+    @Test
+    fun `maps known error codes to the corresponding PurchasesErrorCode`() {
+        assertEquals(PurchasesErrorCode.UnknownError, nsError(code = 0).toPurchasesErrorOrThrow().code)
+        assertEquals(PurchasesErrorCode.PurchaseCancelledError, nsError(code = 1).toPurchasesErrorOrThrow().code)
+        assertEquals(
+            PurchasesErrorCode.TestStoreSimulatedPurchaseError,
+            nsError(code = 42).toPurchasesErrorOrThrow().code,
+        )
+    }
+
+    @Test
+    fun `maps the localized description to the underlying error message`() {
+        val error = nsError(code = 10, description = "network down").toPurchasesErrorOrThrow()
+
+        assertEquals(PurchasesErrorCode.NetworkError, error.code)
+        assertEquals("network down", error.underlyingErrorMessage)
+    }
+
+    @Test
+    fun `throws on unknown error codes`() {
+        assertFailsWith<IllegalStateException> { nsError(code = 12345).toPurchasesErrorOrThrow() }
+    }
+
+    private fun nsError(code: Int, description: String? = null): NSError =
+        NSError.errorWithDomain(
+            domain = "RCPurchasesErrorDomain",
+            code = code.convert(),
+            userInfo = description?.let { mapOf(NSLocalizedDescriptionKey to it) },
+        )
+}

--- a/mappings/src/appleTest/kotlin/com/revenuecat/purchases/kmp/mappings/PriceTest.kt
+++ b/mappings/src/appleTest/kotlin/com/revenuecat/purchases/kmp/mappings/PriceTest.kt
@@ -1,0 +1,29 @@
+package com.revenuecat.purchases.kmp.mappings
+
+import platform.Foundation.NSDecimalNumber
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PriceTest {
+
+    // Regression test: the decimal-to-micros conversion used longValue, which is 32-bit on
+    // watchosArm64 (arm64_32) and truncates amounts beyond 2147.48 currency units in micros.
+    @Test
+    fun `amountMicros preserves values beyond 32 bits`() {
+        val price = priceOrNull(
+            currencyCode = "KRW",
+            formatted = "₩10,000",
+            amountDecimal = NSDecimalNumber(string = "10000"),
+        )
+
+        assertEquals(10_000_000_000L, price?.amountMicros)
+        assertEquals("KRW", price?.currencyCode)
+    }
+
+    @Test
+    fun `returns null when formatted or amount is missing`() {
+        assertNull(priceOrNull(currencyCode = "USD", formatted = null, amountDecimal = NSDecimalNumber.one))
+        assertNull(priceOrNull(currencyCode = "USD", formatted = "$1.00", amountDecimal = null))
+    }
+}

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.revenuecat.purchases.kmp.buildlogic.watchosTargets
+
 plugins {
     id("revenuecat-library")
 }
@@ -7,6 +9,8 @@ revenueCat {
 }
 
 kotlin {
+    watchosTargets()
+
     sourceSets {
         androidMain.dependencies {
             implementation(libs.revenuecat.android)

--- a/result/api/result.klib.api
+++ b/result/api/result.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/result/build.gradle.kts
+++ b/result/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.revenuecat.purchases.kmp.buildlogic.watchosTargets
+
 plugins {
     id("revenuecat-library")
 }
@@ -7,6 +9,8 @@ revenueCat {
 }
 
 kotlin {
+    watchosTargets()
+
     sourceSets {
         commonMain.dependencies {
             implementation(projects.core)


### PR DESCRIPTION
Resolves #126 for watchOS. tvOS and macOS are left for follow-ups.

### Checklist

- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other
  hybrids

### Description

Adds the `watchosArm64`, `watchosDeviceArm64` and `watchosSimulatorArm64` targets to all published modules except `-ui`, which stays iOS only (`either` also skips `watchosDeviceArm64`: arrow-core does not publish it). Minimum versions: watchOS 7.0 (9.0 on `watchosDeviceArm64`).

- The two APIs that do not exist on watchOS (`presentCodeRedemptionSheet`, `showStoreMessagesForTypes`) log and no-op there via internal `expect`/`actual` helpers.
- `NSInteger` is 32-bit on arm64_32 (`watchosArm64`), so mapping code handles variable-width types, with new unit tests.
- CI: new self-contained `build-and-test-watchos` job in parallel to the iOS jobs. `update-error-codes` now outputs `errors.apple.kt`, so RevenueCat/purchases-error-codes#24 must merge first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New published Kotlin/Native targets and Apple interop mapping changes (including 32-bit NSInteger on watchosArm64) can affect published artifacts and price/error conversions. Existing iOS APIs stay source-compatible; watchOS-only APIs no-op rather than crash.
> 
> **Overview**
> Adds **watchOS** as a published platform (`watchosArm64`, `watchosDeviceArm64`, `watchosSimulatorArm64`) for core, models, mappings, kn-core, and result. `-ui` stays iOS-only; `either` omits `watchosDeviceArm64` because arrow-core does not publish it. Minimum versions: watchOS 7.0 (9.0 on `watchosDeviceArm64`).
> 
> APIs that do not exist on watchOS (`presentCodeRedemptionSheet`, `showInAppMessagesIfNeeded`) are split via `expect`/`actual` so iOS still calls native APIs and watchOS logs and no-ops. Availability messages now mention watchOS where relevant (win-backs, ad tracking, paywall tracking).
> 
> Apple mappings handle **32-bit `NSInteger` on arm64_32**: prices use `longLongValue`, error codes convert via `toLong()`, and `revenueMicros` is clamped with `toNSInteger()`. New appleTest coverage for those conversions.
> 
> CI adds a self-contained `build-and-test-watchos` job (compile, metadata, simulator tests, device link) on non-release and release-branch workflows. Error-code generation now writes `errors.apple.kt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9124764a9e8bfabc1c3ba57f22d6ad5d5836c69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->