### PR TITLE
feat(ads): ad reward sample app

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import org.jetbrains.compose.internal.utils.getLocalProperty
+import org.jetbrains.kotlin.gradle.tasks.CInteropProcess
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeLink
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -7,6 +9,56 @@ plugins {
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.codingfeline.buildkonfig)
+}
+
+// Local-only manual test of a real rewarded-ad SSV flow (see RewardVerificationTestingScreen).
+// GoogleMobileAds is vendored via Google's official SPM package
+// (github.com/googleads/swift-package-manager-google-mobile-ads) rather than committed, since
+// it's a ~37MB binary XCFramework. src/swift/GoogleMobileAdsVendor is a minimal wrapper package
+// that depends on it purely so `swift build` resolves and checksum-verifies the binary; we still
+// cinterop directly against the raw XCFramework below, since it's a prebuilt Objective-C binary
+// with no Swift source of ours to run through the swiftPackage() cinterop pipeline.
+val googleMobileAdsVendorDir = layout.projectDirectory.dir("src/swift/GoogleMobileAdsVendor").asFile
+val googleMobileAdsScratchDir = layout.buildDirectory.dir("swift-vendor/GoogleMobileAdsVendor").get().asFile
+val googleMobileAdsFrameworksDir = googleMobileAdsScratchDir.resolve(
+    "artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework"
+)
+
+val resolveGoogleMobileAds by tasks.registering {
+    val vendorDir = googleMobileAdsVendorDir
+    val scratchDir = googleMobileAdsScratchDir
+    val markerFile = googleMobileAdsFrameworksDir.resolve("Info.plist")
+    outputs.dir(googleMobileAdsFrameworksDir)
+    doLast {
+        if (markerFile.exists()) return@doLast
+
+        // Plain ProcessBuilder (not providers.exec/project.exec) to avoid config-cache
+        // "script object reference" serialization failures from this ad-hoc task.
+        fun run(vararg command: String, workingDir: File? = null, extraEnv: Map<String, String> = emptyMap()): String {
+            val process = ProcessBuilder(*command)
+                .apply { workingDir?.let { directory(it) } }
+                .apply { environment().putAll(extraEnv) }
+                .start()
+            val stdout = process.inputStream.bufferedReader().readText()
+            val stderr = process.errorStream.bufferedReader().readText()
+            check(process.waitFor() == 0) { "Command failed: ${command.joinToString(" ")}\n$stderr" }
+            return stdout
+        }
+
+        val sdkPath = run("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").trim()
+        run(
+            "xcrun", "swift", "build",
+            "--target", "GoogleMobileAdsVendor",
+            "--configuration", "debug",
+            "--triple", "arm64-apple-ios-simulator",
+            "--scratch-path", scratchDir.absolutePath,
+            "-Xswiftc", "-sdk", "-Xswiftc", sdkPath,
+            "-Xcc", "-isysroot", "-Xcc", sdkPath,
+            // Avoids trying to use the iOS SDK to parse Package.swift when building from Xcode.
+            workingDir = vendorDir,
+            extraEnv = mapOf("SDKROOT" to ""),
+        )
+    }
 }
 
 kotlin {
@@ -23,9 +75,22 @@ kotlin {
         iosArm64(),
         iosSimulatorArm64()
     ).forEach { iosTarget ->
+        val frameworkSlice = if (iosTarget.name == "iosArm64") "ios-arm64" else "ios-arm64_x86_64-simulator"
+        val frameworkSearchDir = googleMobileAdsFrameworksDir.resolve(frameworkSlice)
+
+        iosTarget.compilations.getByName("main") {
+            cinterops {
+                create("GoogleMobileAds") {
+                    defFile(project.file("src/iosMain/cinterop/GoogleMobileAds.def"))
+                    compilerOpts("-F${frameworkSearchDir.absolutePath}")
+                }
+            }
+        }
+
         iosTarget.binaries.framework {
             baseName = "ComposeApp"
             isStatic = true
+            linkerOpts("-F${frameworkSearchDir.absolutePath}", "-framework", "GoogleMobileAds")
         }
     }
 
@@ -52,6 +117,7 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
+            implementation(libs.google.mobileAds)
         }
     }
 }
@@ -125,4 +191,14 @@ buildkonfig {
             }
         }
     }
+}
+
+tasks.withType<CInteropProcess>().configureEach {
+    if (name.contains("GoogleMobileAds")) {
+        dependsOn(resolveGoogleMobileAds)
+    }
+}
+
+tasks.withType<KotlinNativeLink>().configureEach {
+    dependsOn(resolveGoogleMobileAds)
 }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -27,6 +27,11 @@
                 <data android:scheme="rc-39976e83d0" />
             </intent-filter>
         </activity>
+
+        <!-- Google's official test App ID. Always safe to commit. -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
     </application>
 
 </manifest>

--- a/composeApp/src/androidMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardedAdController.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardedAdController.android.kt
@@ -1,0 +1,83 @@
+package com.revenuecat.purchases.kmp.sample
+
+import android.app.Activity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions
+import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
+import com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAdLoadCallback
+
+private var didStartGoogleMobileAds = false
+
+private fun ensureGoogleMobileAdsStarted(activity: Activity) {
+    if (didStartGoogleMobileAds) return
+    didStartGoogleMobileAds = true
+    MobileAds.initialize(activity)
+}
+
+actual class RewardedAdController {
+
+    private var rewardedAd: RewardedInterstitialAd? = null
+
+    actual fun loadAd(
+        adUnitId: String,
+        presentingHost: Any?,
+        onLoaded: (responseId: String) -> Unit,
+        onFailedToLoad: (String) -> Unit,
+    ) {
+        val activity = presentingHost as? Activity ?: run {
+            onFailedToLoad("No Activity available to load the ad.")
+            return
+        }
+        ensureGoogleMobileAdsStarted(activity)
+        RewardedInterstitialAd.load(
+            activity,
+            adUnitId,
+            AdRequest.Builder().build(),
+            object : RewardedInterstitialAdLoadCallback() {
+                override fun onAdLoaded(ad: RewardedInterstitialAd) {
+                    rewardedAd = ad
+                    onLoaded(ad.responseInfo.responseId.orEmpty())
+                }
+
+                override fun onAdFailedToLoad(error: LoadAdError) {
+                    rewardedAd = null
+                    onFailedToLoad(error.message)
+                }
+            },
+        )
+    }
+
+    actual fun setServerSideVerificationOptions(userId: String, customData: String) {
+        val options = ServerSideVerificationOptions.Builder()
+            .setUserId(userId)
+            .setCustomData(customData)
+            .build()
+        rewardedAd?.setServerSideVerificationOptions(options)
+    }
+
+    actual fun present(presentingHost: Any?, onUserEarnedReward: () -> Unit, onDismissed: () -> Unit) {
+        val ad = rewardedAd
+        val activity = presentingHost as? Activity
+        if (ad == null || activity == null) {
+            onDismissed()
+            return
+        }
+        rewardedAd = null
+        ad.fullScreenContentCallback = object : FullScreenContentCallback() {
+            override fun onAdDismissedFullScreenContent() {
+                onDismissed()
+            }
+        }
+        ad.show(activity) { onUserEarnedReward() }
+    }
+}
+
+@Composable
+actual fun rememberAdPresentingHost(): Any? = LocalContext.current as? Activity
+
+actual val rewardedAdUnitId: String = "ca-app-pub-3940256099942544/5354046379"

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/App.kt
@@ -133,6 +133,10 @@ fun App() {
                     navigateTo = navigateTo
                 )
 
+                is Screen.RewardVerificationTesting -> RewardVerificationTestingScreen(
+                    navigateTo = navigateTo
+                )
+
                 is Screen.CustomPaywallTracking -> CustomPaywallTrackingScreen(
                     navigateTo = navigateTo
                 )

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/MainScreen.kt
@@ -218,6 +218,14 @@ fun MainScreen(
 
                 Spacer(modifier = Modifier.size(16.dp))
                 TextButton(
+                    onClick = { navigateTo(Screen.RewardVerificationTesting) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Reward Verification Testing")
+                }
+
+                Spacer(modifier = Modifier.size(16.dp))
+                TextButton(
                     onClick = { navigateTo(Screen.CustomPaywallTracking) },
                     modifier = Modifier.fillMaxWidth()
                 ) {

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardVerificationTestingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardVerificationTestingScreen.kt
@@ -1,0 +1,175 @@
+@file:OptIn(ExperimentalRevenueCatApi::class)
+
+package com.revenuecat.purchases.kmp.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.Purchases
+import com.revenuecat.purchases.kmp.models.RewardVerificationResult
+import com.revenuecat.purchases.kmp.models.RewardVerificationToken
+import com.revenuecat.purchases.kmp.models.VerifiedReward
+
+private fun describeReward(reward: VerifiedReward): String =
+    when (reward) {
+        is VerifiedReward.VirtualCurrency -> "+${reward.amount} ${reward.code}"
+        is VerifiedReward.Entitlement -> "entitlement \"${reward.identifier}\""
+        VerifiedReward.NoReward -> "no reward"
+        VerifiedReward.UnsupportedReward -> "unsupported reward"
+    }
+
+@Composable
+fun RewardVerificationTestingScreen(
+    navigateTo: (Screen) -> Unit
+) {
+    val controller = remember { RewardedAdController() }
+    val presentingHost = rememberAdPresentingHost()
+    var status by remember { mutableStateOf("Tap \"Load ad\" to begin.") }
+    var messageColor by remember { mutableStateOf(Color.Gray) }
+    var token by remember { mutableStateOf<RewardVerificationToken?>(null) }
+    var adReady by remember { mutableStateOf(false) }
+
+    fun loadAd() {
+        adReady = false
+        token = null
+        status = "Loading ad…"
+        messageColor = Color.Gray
+
+        controller.loadAd(
+            adUnitId = rewardedAdUnitId,
+            presentingHost = presentingHost,
+            onLoaded = { responseId ->
+                val generatedToken = Purchases.sharedInstance.generateRewardVerificationToken(responseId)
+                token = generatedToken
+                controller.setServerSideVerificationOptions(
+                    userId = generatedToken.appUserID,
+                    customData = generatedToken.customData
+                )
+                adReady = true
+                status = "Ad ready. impressionId: $responseId"
+                messageColor = Color.Gray
+            },
+            onFailedToLoad = { error ->
+                status = "Failed to load: $error"
+                messageColor = Color.Red
+            }
+        )
+    }
+
+    fun describeResult(result: RewardVerificationResult): String {
+        val reward = result.verifiedReward
+        if (result.failed || reward == null) return "❌ verification failed"
+        val more = if (result.moreRewards.isEmpty()) "" else " (+${result.moreRewards.size} more)"
+        return "✅ ${describeReward(reward)}$more"
+    }
+
+    fun showAd() {
+        val clientTransactionId = token?.clientTransactionId ?: return
+        adReady = false
+        controller.present(
+            presentingHost = presentingHost,
+            onUserEarnedReward = {
+                status = "Verifying reward…"
+                messageColor = Color.Gray
+                Purchases.sharedInstance.pollRewardVerification(clientTransactionId) { result ->
+                    status = describeResult(result)
+                    messageColor = if (result.failed) Color.Red else Color.Green
+                }
+            },
+            onDismissed = { loadAd() }
+        )
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Reward Verification Testing",
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.h4
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Manual test of generateRewardVerificationToken() / pollRewardVerification() " +
+                "against a real rewarded ad.",
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            color = Color.Gray,
+            style = MaterialTheme.typography.body1
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = { loadAd() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Load ad")
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Button(
+            onClick = { showAd() },
+            enabled = adReady,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Watch ad to earn reward")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = messageColor.copy(alpha = 0.1f),
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .padding(16.dp)
+        ) {
+            Text(
+                text = status,
+                color = messageColor.copy(alpha = 0.8f),
+                style = MaterialTheme.typography.body2
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        TextButton(
+            onClick = { navigateTo(Screen.Main) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Back")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardVerificationTestingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardVerificationTestingScreen.kt
@@ -88,9 +88,11 @@ fun RewardVerificationTestingScreen(
     fun showAd() {
         val clientTransactionId = token?.clientTransactionId ?: return
         adReady = false
+        var rewardEarned = false
         controller.present(
             presentingHost = presentingHost,
             onUserEarnedReward = {
+                rewardEarned = true
                 status = "Verifying reward…"
                 messageColor = Color.Gray
                 Purchases.sharedInstance.pollRewardVerification(clientTransactionId) { result ->
@@ -98,7 +100,9 @@ fun RewardVerificationTestingScreen(
                     messageColor = if (result.failed) Color.Red else Color.Green
                 }
             },
-            onDismissed = { loadAd() }
+            onDismissed = {
+                if (!rewardEarned) loadAd()
+            }
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardedAdController.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardedAdController.kt
@@ -1,0 +1,30 @@
+package com.revenuecat.purchases.kmp.sample
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Local-only manual test harness for a real rewarded-ad SSV flow. iOS delegates to GoogleMobileAds
+ * directly via cinterop; Android delegates to the play-services-ads SDK.
+ */
+expect class RewardedAdController() {
+    fun loadAd(
+        adUnitId: String,
+        presentingHost: Any?,
+        onLoaded: (responseId: String) -> Unit,
+        onFailedToLoad: (String) -> Unit,
+    )
+    fun setServerSideVerificationOptions(userId: String, customData: String)
+    fun present(presentingHost: Any?, onUserEarnedReward: () -> Unit, onDismissed: () -> Unit)
+}
+
+/**
+ * The platform object [RewardedAdController] needs to load/show a full-screen ad: an `Activity` on
+ * Android, unused on iOS (which resolves its own root view controller and doesn't need a `Context`
+ * to load an ad either).
+ */
+@Composable
+expect fun rememberAdPresentingHost(): Any?
+
+// Google's official test rewarded-ad unit for each platform. Always fills with a test ad and is
+// safe to commit.
+expect val rewardedAdUnitId: String

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/Screen.kt
@@ -13,6 +13,7 @@ sealed interface Screen {
     data object CustomerCenter : Screen
     data object VirtualCurrencyTesting : Screen
     data object AdTracking : Screen
+    data object RewardVerificationTesting : Screen
     data object CustomVariablesEditor : Screen
     data object CustomPaywallTracking : Screen
     data object SubscriberAttributesTesting : Screen

--- a/composeApp/src/iosMain/cinterop/GoogleMobileAds.def
+++ b/composeApp/src/iosMain/cinterop/GoogleMobileAds.def
@@ -1,0 +1,3 @@
+language = Objective-C
+modules = GoogleMobileAds
+package = com.revenuecat.purchases.kmp.sample.ads.gma

--- a/composeApp/src/iosMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardedAdController.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/revenuecat/purchases/kmp/sample/RewardedAdController.ios.kt
@@ -1,0 +1,69 @@
+package com.revenuecat.purchases.kmp.sample
+
+import androidx.compose.runtime.Composable
+import com.revenuecat.purchases.kmp.sample.ads.gma.GADFullScreenContentDelegateProtocol
+import com.revenuecat.purchases.kmp.sample.ads.gma.GADFullScreenPresentingAdProtocol
+import com.revenuecat.purchases.kmp.sample.ads.gma.GADMobileAds
+import com.revenuecat.purchases.kmp.sample.ads.gma.GADRequest
+import com.revenuecat.purchases.kmp.sample.ads.gma.GADRewardedInterstitialAd
+import com.revenuecat.purchases.kmp.sample.ads.gma.GADServerSideVerificationOptions
+import platform.darwin.NSObject
+
+private var didStartGoogleMobileAds = false
+
+private fun ensureGoogleMobileAdsStarted() {
+    if (didStartGoogleMobileAds) return
+    didStartGoogleMobileAds = true
+    GADMobileAds.sharedInstance.startWithCompletionHandler(null)
+}
+
+actual class RewardedAdController {
+
+    private var rewardedAd: GADRewardedInterstitialAd? = null
+
+    actual fun loadAd(
+        adUnitId: String,
+        presentingHost: Any?,
+        onLoaded: (responseId: String) -> Unit,
+        onFailedToLoad: (String) -> Unit,
+    ) {
+        ensureGoogleMobileAdsStarted()
+        GADRewardedInterstitialAd.loadWithAdUnitID(adUnitId, GADRequest()) { ad, error ->
+            if (error != null) {
+                onFailedToLoad(error.localizedDescription)
+                return@loadWithAdUnitID
+            }
+            rewardedAd = ad
+            onLoaded(ad?.responseInfo?.responseIdentifier ?: "")
+        }
+    }
+
+    actual fun setServerSideVerificationOptions(userId: String, customData: String) {
+        val options = GADServerSideVerificationOptions()
+        options.userIdentifier = userId
+        options.customRewardString = customData
+        rewardedAd?.serverSideVerificationOptions = options
+    }
+
+    actual fun present(presentingHost: Any?, onUserEarnedReward: () -> Unit, onDismissed: () -> Unit) {
+        val ad = rewardedAd
+        if (ad == null) {
+            onDismissed()
+            return
+        }
+        rewardedAd = null
+        ad.fullScreenContentDelegate = object : NSObject(), GADFullScreenContentDelegateProtocol {
+            override fun adDidDismissFullScreenContent(ad: GADFullScreenPresentingAdProtocol) {
+                onDismissed()
+            }
+        }
+        ad.presentFromRootViewController(viewController = null) {
+            onUserEarnedReward()
+        }
+    }
+}
+
+@Composable
+actual fun rememberAdPresentingHost(): Any? = null
+
+actual val rewardedAdUnitId: String = "ca-app-pub-3940256099942544/6978759866"

--- a/composeApp/src/swift/GoogleMobileAdsVendor/Package.resolved
+++ b/composeApp/src/swift/GoogleMobileAdsVendor/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads.git",
+      "state" : {
+        "revision" : "1239c23464503053c17d37ee5daa70de3455e9c8",
+        "version" : "12.14.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "13b248eaa73b7826f0efb1bcf455e251d65ecb1b",
+        "version" : "3.1.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/composeApp/src/swift/GoogleMobileAdsVendor/Package.swift
+++ b/composeApp/src/swift/GoogleMobileAdsVendor/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "GoogleMobileAdsVendor",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(name: "GoogleMobileAdsVendor", targets: ["GoogleMobileAdsVendor"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/googleads/swift-package-manager-google-mobile-ads.git", from: "12.14.0")
+    ],
+    targets: [
+        .target(
+            name: "GoogleMobileAdsVendor",
+            dependencies: [
+                .product(name: "GoogleMobileAds", package: "swift-package-manager-google-mobile-ads")
+            ]
+        )
+    ]
+)

--- a/composeApp/src/swift/GoogleMobileAdsVendor/Sources/GoogleMobileAdsVendor/GoogleMobileAdsVendor.swift
+++ b/composeApp/src/swift/GoogleMobileAdsVendor/Sources/GoogleMobileAdsVendor/GoogleMobileAdsVendor.swift
@@ -1,0 +1,1 @@
+@_exported import GoogleMobileAds

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ mavenPublish-gradlePlugin = { module = "com.vanniktech:gradle-maven-publish-plug
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.0" }
 androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.1.1" }
 arrow-core = { module = "io.arrow-kt:arrow-core", version = "1.2.4" }
+google-mobileAds = { module = "com.google.android.gms:play-services-ads", version = "23.6.0" }
 junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-core = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,11 @@
 TEAM_ID=
 BUNDLE_ID=com.revenuecat.sampleapp
 APP_NAME=purchases-kmp Sample
+
+// GoogleMobileAds is only bound via cinterop inside ComposeApp.framework; the app target's own
+// link step also needs the framework search path + link flag, since Kotlin/Native's static
+// framework doesn't re-export external ObjC framework dependencies to its consumer.
+GOOGLE_MOBILE_ADS_XCFRAMEWORK_DIR = $(PROJECT_DIR)/../composeApp/build/swift-vendor/GoogleMobileAdsVendor/artifacts/swift-package-manager-google-mobile-ads/GoogleMobileAds/GoogleMobileAds.xcframework
+FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*] = $(GOOGLE_MOBILE_ADS_XCFRAMEWORK_DIR)/ios-arm64_x86_64-simulator
+FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*] = $(GOOGLE_MOBILE_ADS_XCFRAMEWORK_DIR)/ios-arm64
+OTHER_LDFLAGS = $(inherited) -framework GoogleMobileAds -framework AdSupport -framework AudioToolbox -framework AVFoundation -framework CFNetwork -framework CoreGraphics -framework CoreMedia -framework CoreTelephony -framework CoreVideo -framework JavaScriptCore -framework MediaPlayer -framework MessageUI -framework Network -framework QuartzCore -framework SafariServices -framework Security -framework StoreKit -framework SystemConfiguration -framework WebKit -lsqlite3 -lz

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -311,6 +311,7 @@
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
 					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\n$(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = iosApp/Info.plist;
@@ -343,6 +344,7 @@
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
 					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)\n$(SRCROOT)/../composeApp/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
 				);
 				INFOPLIST_FILE = iosApp/Info.plist;

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -33,6 +33,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Description

Adds an example app section for ad rewards. It can be used to understand how to wire a KMP app with RC rewarded ads.

![Screenshot 2026-08-10 at 16.38.43.png](https://app.graphite.com/user-attachments/assets/a6c2eaaf-349a-455e-8a66-1dcc39a2df6a.png)



<!-- Describe your changes in detail -->

<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to the sample app and build wiring for Google Ads, but iOS linking/cinterop and Gradle native build tasks add non-trivial build risk for anyone building the sample on Apple platforms.
> 
> **Overview**
> Adds a **Reward Verification Testing** flow to the KMP sample app so developers can manually exercise `generateRewardVerificationToken()` and `pollRewardVerification()` against real Google rewarded interstitial ads (official test ad units on Android and iOS).
> 
> The sample wires a new `expect`/`actual` `RewardedAdController` that loads and presents ads, applies server-side verification options from the RC token, then polls verification after the user earns the reward. Navigation is hooked from the main menu and `App` routing.
> 
> **Android** adds `play-services-ads`, the test `APPLICATION_ID` in the manifest, and an `Activity`-based controller implementation.
> 
> **iOS** vendors Google Mobile Ads via a small Swift package wrapper and a Gradle task that runs `swift build` to fetch the XCFramework; Kotlin/Native **cinterop** links against `GoogleMobileAds`, with `iosApp` xcconfig/pbxproj updates so the app target also links the framework and its dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87789cb25becb532d2d92e7ace1622e47cb4e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->