### PR TITLE
Stop featuring either in the sample app

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -112,7 +112,6 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
             implementation(projects.core)
             implementation(projects.result)
-            implementation(projects.either)
             implementation(projects.revenuecatui)
         }
         androidMain.dependencies {

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/MainScreen.kt
@@ -33,17 +33,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import arrow.core.Either
 import com.revenuecat.purchases.kmp.Purchases
 import com.revenuecat.purchases.kmp.PurchasesConfiguration
 import com.revenuecat.purchases.kmp.PurchasesDelegate
 import com.revenuecat.purchases.kmp.models.PurchasesAreCompletedBy
 import com.revenuecat.purchases.kmp.models.StoreKitVersion
-import com.revenuecat.purchases.kmp.either.awaitOfferingsEither
 import com.revenuecat.purchases.kmp.ktx.awaitCustomerInfo
+import com.revenuecat.purchases.kmp.ktx.awaitOfferings
 import com.revenuecat.purchases.kmp.models.CustomerInfo
 import com.revenuecat.purchases.kmp.models.Offerings
 import com.revenuecat.purchases.kmp.models.PurchasesError
+import com.revenuecat.purchases.kmp.models.PurchasesException
 import com.revenuecat.purchases.kmp.models.StoreProduct
 import com.revenuecat.purchases.kmp.models.StoreTransaction
 import com.revenuecat.purchases.kmp.ui.revenuecatui.CustomVariableValue
@@ -131,11 +131,11 @@ fun MainScreen(
                     mutableStateOf(AsyncState.Loading)
                 }
                 LaunchedEffect(Unit) {
-                    offeringsState =
-                        when (val offerings = Purchases.sharedInstance.awaitOfferingsEither()) {
-                            is Either.Left -> AsyncState.Error
-                            is Either.Right -> AsyncState.Loaded(offerings.value)
-                        }
+                    offeringsState = try {
+                        AsyncState.Loaded(Purchases.sharedInstance.awaitOfferings())
+                    } catch (e: PurchasesException) {
+                        AsyncState.Error
+                    }
                 }
                 val customerInfo by Purchases.sharedInstance.rememberCustomerInfoState()
                 val customerInfoState by remember {

--- a/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/revenuecat/purchases/kmp/sample/MainScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -127,13 +128,10 @@ fun MainScreen(
                         navigateTo(Screen.PaywallFooter(offering = null))
                     }
                 }
-                var offeringsState: AsyncState<Offerings> by remember {
-                    mutableStateOf(AsyncState.Loading)
-                }
-                LaunchedEffect(Unit) {
-                    offeringsState = try {
+                val offeringsState by produceState<AsyncState<Offerings>>(AsyncState.Loading) {
+                    value = try {
                         AsyncState.Loaded(Purchases.sharedInstance.awaitOfferings())
-                    } catch (e: PurchasesException) {
+                    } catch (_: PurchasesException) {
                         AsyncState.Error
                     }
                 }


### PR DESCRIPTION
- Stops the sample app from featuring the `either` module, it is an optional module and we shouldn't show it as the default example.
- No public API changes: `composeApp` isn't a published artifact.

### Checklist

- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other
  hybrids

<details><summary>Agent description</summary>

### Motivation

Part of [SDK-4403](https://linear.app/revenuecat/issue/SDK-4403): `either` is a thin, unmaintained wrapper around `arrow.core.Either`, and everything it does is also available via plain suspend functions already shipped in `core`'s `ktx` package. The sample app using it reads as an implicit recommendation, so it's now updated to use the plain suspend function instead. The `either` module itself keeps publishing and is unaffected; the docs.revenuecat.com install snippet already lists it as optional and doesn't need a change.

### Description

- `MainScreen.kt`: replaced the `awaitOfferingsEither()` call and its `Either.Left`/`Either.Right` branching with `core`'s `awaitOfferings()` in a `try`/`catch (PurchasesException)`, matching the catch style already used elsewhere in the same file.
- `composeApp/build.gradle.kts`: dropped the `implementation(projects.either)` dependency, which also removes the transitive `arrow-core` dependency from the sample app.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sample-only refactor with no public SDK or production behavior changes.
> 
> **Overview**
> Stops the sample app from depending on the optional `either` module so it no longer looks like the default API.
> 
> `MainScreen` now loads offerings with `awaitOfferings()` and `try`/`catch` on `PurchasesException` via `produceState`, instead of `awaitOfferingsEither()`. The sample Gradle config drops `projects.either`. No published API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff27202017479fc20d5269b83683744d567aef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->