### PR TITLE
chore(ads): align ad tracking class visibility

### DIFF
--- a/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.android.kt
+++ b/mappings/src/androidMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.android.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.ExperimentalPreviewRevenueCatPurchasesAPI
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.InternalRevenueCatApi
 import com.revenuecat.purchases.kmp.models.AdDisplayedData
 import com.revenuecat.purchases.kmp.models.AdFailedToLoadData
 import com.revenuecat.purchases.kmp.models.AdFormat
@@ -20,19 +21,19 @@ import com.revenuecat.purchases.ads.events.types.AdRevenueData as AndroidAdReven
 import com.revenuecat.purchases.ads.events.types.AdRevenuePrecision as AndroidAdRevenuePrecision
 
 @ExperimentalRevenueCatApi
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatApi::class)
 public fun AdMediatorName.toAndroid(): AndroidAdMediatorName {
     return AndroidAdMediatorName.fromString(this.value)
 }
 
 @ExperimentalRevenueCatApi
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatApi::class)
 public fun AdRevenuePrecision.toAndroid(): AndroidAdRevenuePrecision {
     return AndroidAdRevenuePrecision.fromString(this.value)
 }
 
 @ExperimentalRevenueCatApi
-@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class)
+@OptIn(ExperimentalPreviewRevenueCatPurchasesAPI::class, InternalRevenueCatApi::class)
 public fun AdFormat.toAndroid(): AndroidAdFormat {
     return AndroidAdFormat.fromString(this.value)
 }

--- a/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.apple.kt
+++ b/mappings/src/appleMain/kotlin/com/revenuecat/purchases/kmp/mappings/AdEventTypes.apple.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.kmp.mappings
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.InternalRevenueCatApi
 import com.revenuecat.purchases.kmp.models.AdDisplayedData
 import com.revenuecat.purchases.kmp.models.AdFailedToLoadData
 import com.revenuecat.purchases.kmp.models.AdFormat
@@ -21,14 +22,17 @@ import com.revenuecat.purchases.kn.core.RCAdRevenuePrecision
 import com.revenuecat.purchases.kn.core.RCMediatorName
 
 @ExperimentalRevenueCatApi
+@OptIn(InternalRevenueCatApi::class)
 public fun AdMediatorName.toIos(): RCMediatorName =
     RCMediatorName(rawValue = value)
 
 @ExperimentalRevenueCatApi
+@OptIn(InternalRevenueCatApi::class)
 public fun AdRevenuePrecision.toIos(): RCAdRevenuePrecision =
     RCAdRevenuePrecision(rawValue = value)
 
 @ExperimentalRevenueCatApi
+@OptIn(InternalRevenueCatApi::class)
 public fun AdFormat.toIos(): RCAdFormat =
     RCAdFormat(rawValue = value)
 

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -1,6 +1,9 @@
 public abstract interface annotation class com/revenuecat/purchases/kmp/ExperimentalRevenueCatApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/revenuecat/purchases/kmp/InternalRevenueCatApi : java/lang/annotation/Annotation {
+}
+
 public final class com/revenuecat/purchases/kmp/models/AdDisplayedData {
 	public fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/AdMediatorName;Lcom/revenuecat/purchases/kmp/models/AdFormat;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/revenuecat/purchases/kmp/models/AdMediatorName;Lcom/revenuecat/purchases/kmp/models/AdFormat;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -23,8 +26,9 @@ public final class com/revenuecat/purchases/kmp/models/AdFailedToLoadData {
 
 public final class com/revenuecat/purchases/kmp/models/AdFormat {
 	public static final field Companion Lcom/revenuecat/purchases/kmp/models/AdFormat$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
 }
 
 public final class com/revenuecat/purchases/kmp/models/AdFormat$Companion {
@@ -50,8 +54,9 @@ public final class com/revenuecat/purchases/kmp/models/AdLoadedData {
 
 public final class com/revenuecat/purchases/kmp/models/AdMediatorName {
 	public static final field Companion Lcom/revenuecat/purchases/kmp/models/AdMediatorName$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
 }
 
 public final class com/revenuecat/purchases/kmp/models/AdMediatorName$Companion {
@@ -86,8 +91,9 @@ public final class com/revenuecat/purchases/kmp/models/AdRevenueData {
 
 public final class com/revenuecat/purchases/kmp/models/AdRevenuePrecision {
 	public static final field Companion Lcom/revenuecat/purchases/kmp/models/AdRevenuePrecision$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
 }
 
 public final class com/revenuecat/purchases/kmp/models/AdRevenuePrecision$Companion {

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -10,6 +10,10 @@ open annotation class com.revenuecat.purchases.kmp/ExperimentalRevenueCatApi : k
     constructor <init>() // com.revenuecat.purchases.kmp/ExperimentalRevenueCatApi.<init>|<init>(){}[0]
 }
 
+open annotation class com.revenuecat.purchases.kmp/InternalRevenueCatApi : kotlin/Annotation { // com.revenuecat.purchases.kmp/InternalRevenueCatApi|null[0]
+    constructor <init>() // com.revenuecat.purchases.kmp/InternalRevenueCatApi.<init>|<init>(){}[0]
+}
+
 final enum class com.revenuecat.purchases.kmp.models/BillingFeature : kotlin/Enum<com.revenuecat.purchases.kmp.models/BillingFeature> { // com.revenuecat.purchases.kmp.models/BillingFeature|null[0]
     enum entry PRICE_CHANGE_CONFIRMATION // com.revenuecat.purchases.kmp.models/BillingFeature.PRICE_CHANGE_CONFIRMATION|null[0]
     enum entry SUBSCRIPTIONS // com.revenuecat.purchases.kmp.models/BillingFeature.SUBSCRIPTIONS|null[0]
@@ -568,10 +572,11 @@ final class com.revenuecat.purchases.kmp.models/AdFailedToLoadData { // com.reve
 }
 
 final class com.revenuecat.purchases.kmp.models/AdFormat { // com.revenuecat.purchases.kmp.models/AdFormat|null[0]
-    constructor <init>(kotlin/String) // com.revenuecat.purchases.kmp.models/AdFormat.<init>|<init>(kotlin.String){}[0]
-
     final val value // com.revenuecat.purchases.kmp.models/AdFormat.value|{}value[0]
         final fun <get-value>(): kotlin/String // com.revenuecat.purchases.kmp.models/AdFormat.value.<get-value>|<get-value>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.revenuecat.purchases.kmp.models/AdFormat.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.revenuecat.purchases.kmp.models/AdFormat.hashCode|hashCode(){}[0]
 
     final object Companion { // com.revenuecat.purchases.kmp.models/AdFormat.Companion|null[0]
         final val APP_OPEN // com.revenuecat.purchases.kmp.models/AdFormat.Companion.APP_OPEN|{}APP_OPEN[0]
@@ -609,10 +614,11 @@ final class com.revenuecat.purchases.kmp.models/AdLoadedData { // com.revenuecat
 }
 
 final class com.revenuecat.purchases.kmp.models/AdMediatorName { // com.revenuecat.purchases.kmp.models/AdMediatorName|null[0]
-    constructor <init>(kotlin/String) // com.revenuecat.purchases.kmp.models/AdMediatorName.<init>|<init>(kotlin.String){}[0]
-
     final val value // com.revenuecat.purchases.kmp.models/AdMediatorName.value|{}value[0]
         final fun <get-value>(): kotlin/String // com.revenuecat.purchases.kmp.models/AdMediatorName.value.<get-value>|<get-value>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.revenuecat.purchases.kmp.models/AdMediatorName.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.revenuecat.purchases.kmp.models/AdMediatorName.hashCode|hashCode(){}[0]
 
     final object Companion { // com.revenuecat.purchases.kmp.models/AdMediatorName.Companion|null[0]
         final val AD_MOB // com.revenuecat.purchases.kmp.models/AdMediatorName.Companion.AD_MOB|{}AD_MOB[0]
@@ -663,10 +669,11 @@ final class com.revenuecat.purchases.kmp.models/AdRevenueData { // com.revenueca
 }
 
 final class com.revenuecat.purchases.kmp.models/AdRevenuePrecision { // com.revenuecat.purchases.kmp.models/AdRevenuePrecision|null[0]
-    constructor <init>(kotlin/String) // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.<init>|<init>(kotlin.String){}[0]
-
     final val value // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.value|{}value[0]
         final fun <get-value>(): kotlin/String // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.value.<get-value>|<get-value>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.hashCode|hashCode(){}[0]
 
     final object Companion { // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.Companion|null[0]
         final val ESTIMATED // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.Companion.ESTIMATED|{}ESTIMATED[0]

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/InternalRevenueCatApi.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/InternalRevenueCatApi.kt
@@ -1,5 +1,11 @@
 package com.revenuecat.purchases.kmp
 
+/**
+ * This annotation marks RevenueCat APIs that are internal and not meant for public consumption.
+ *
+ * APIs marked with this annotation may change frequently and without warning, and are not
+ * covered by semantic versioning guarantees. Do not use in your own code.
+ */
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(
     level = RequiresOptIn.Level.ERROR,

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/InternalRevenueCatApi.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/InternalRevenueCatApi.kt
@@ -1,0 +1,16 @@
+package com.revenuecat.purchases.kmp
+
+@Retention(value = AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is an internal RevenueCat API that may change frequently and without warning. " +
+        "No compatibility guarantees are provided. It is strongly discouraged to use this API.",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS,
+    AnnotationTarget.CONSTRUCTOR,
+)
+public annotation class InternalRevenueCatApi

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
@@ -29,7 +29,7 @@ public class AdFormat internal constructor(@property:InternalRevenueCatApi publi
         public val NATIVE: AdFormat = AdFormat("native")
         public val APP_OPEN: AdFormat = AdFormat("app_open")
 
-        public fun fromString(value: String): AdFormat {
+        internal fun fromString(value: String): AdFormat {
             return when (value.trim()) {
                 "other" -> OTHER
                 "banner" -> BANNER

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
@@ -1,12 +1,13 @@
 package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.InternalRevenueCatApi
 
 /**
  * Common ad format types.
  */
 @ExperimentalRevenueCatApi
-public class AdFormat(public val value: String) {
+public class AdFormat internal constructor(@property:InternalRevenueCatApi public val value: String) {
     public companion object {
         public val OTHER: AdFormat = AdFormat("other")
         public val BANNER: AdFormat = AdFormat("banner")
@@ -15,5 +16,18 @@ public class AdFormat(public val value: String) {
         public val REWARDED_INTERSTITIAL: AdFormat = AdFormat("rewarded_interstitial")
         public val NATIVE: AdFormat = AdFormat("native")
         public val APP_OPEN: AdFormat = AdFormat("app_open")
+
+        public fun fromString(value: String): AdFormat {
+            return when (value.trim()) {
+                "other" -> OTHER
+                "banner" -> BANNER
+                "interstitial" -> INTERSTITIAL
+                "rewarded" -> REWARDED
+                "rewarded_interstitial" -> REWARDED_INTERSTITIAL
+                "native" -> NATIVE
+                "app_open" -> APP_OPEN
+                else -> AdFormat(value)
+            }
+        }
     }
 }

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
@@ -8,6 +8,18 @@ import com.revenuecat.purchases.kmp.InternalRevenueCatApi
  */
 @ExperimentalRevenueCatApi
 public class AdFormat internal constructor(@property:InternalRevenueCatApi public val value: String) {
+    @OptIn(InternalRevenueCatApi::class)
+    public override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AdFormat) return false
+        return value == other.value
+    }
+
+    @OptIn(InternalRevenueCatApi::class)
+    public override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
     public companion object {
         public val OTHER: AdFormat = AdFormat("other")
         public val BANNER: AdFormat = AdFormat("banner")

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
@@ -24,7 +24,7 @@ public class AdMediatorName internal constructor(@property:InternalRevenueCatApi
         public val AD_MOB: AdMediatorName = AdMediatorName("AdMob")
         public val APP_LOVIN: AdMediatorName = AdMediatorName("AppLovin")
 
-        public fun fromString(value: String): AdMediatorName {
+        internal fun fromString(value: String): AdMediatorName {
             return when (value.trim()) {
                 "AdMob" -> AD_MOB
                 "AppLovin" -> APP_LOVIN

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
@@ -8,6 +8,18 @@ import com.revenuecat.purchases.kmp.InternalRevenueCatApi
  */
 @ExperimentalRevenueCatApi
 public class AdMediatorName internal constructor(@property:InternalRevenueCatApi public val value: String) {
+    @OptIn(InternalRevenueCatApi::class)
+    public override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AdMediatorName) return false
+        return value == other.value
+    }
+
+    @OptIn(InternalRevenueCatApi::class)
+    public override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
     public companion object {
         public val AD_MOB: AdMediatorName = AdMediatorName("AdMob")
         public val APP_LOVIN: AdMediatorName = AdMediatorName("AppLovin")

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
@@ -1,14 +1,23 @@
 package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.InternalRevenueCatApi
 
 /**
  * Common ad mediator names.
  */
 @ExperimentalRevenueCatApi
-public class AdMediatorName(public val value: String) {
+public class AdMediatorName internal constructor(@property:InternalRevenueCatApi public val value: String) {
     public companion object {
         public val AD_MOB: AdMediatorName = AdMediatorName("AdMob")
         public val APP_LOVIN: AdMediatorName = AdMediatorName("AppLovin")
+
+        public fun fromString(value: String): AdMediatorName {
+            return when (value.trim()) {
+                "AdMob" -> AD_MOB
+                "AppLovin" -> APP_LOVIN
+                else -> AdMediatorName(value)
+            }
+        }
     }
 }

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
@@ -11,6 +11,18 @@ import com.revenuecat.purchases.kmp.InternalRevenueCatApi
  */
 @ExperimentalRevenueCatApi
 public class AdRevenuePrecision internal constructor(@property:InternalRevenueCatApi public val value: String) {
+    @OptIn(InternalRevenueCatApi::class)
+    public override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AdRevenuePrecision) return false
+        return value == other.value
+    }
+
+    @OptIn(InternalRevenueCatApi::class)
+    public override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
     public companion object {
         /**
          * The revenue value is exact and confirmed by the ad network.

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
@@ -1,6 +1,7 @@
 package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.InternalRevenueCatApi
 
 /**
  * Represents the precision level of ad revenue values reported by ad networks.
@@ -9,7 +10,7 @@ import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
  * This enum helps distinguish between exact reported values and estimates.
  */
 @ExperimentalRevenueCatApi
-public class AdRevenuePrecision(public val value: String) {
+public class AdRevenuePrecision internal constructor(@property:InternalRevenueCatApi public val value: String) {
     public companion object {
         /**
          * The revenue value is exact and confirmed by the ad network.
@@ -39,5 +40,15 @@ public class AdRevenuePrecision(public val value: String) {
          * accuracy of the revenue data, or when the precision cannot be determined.
          */
         public val UNKNOWN: AdRevenuePrecision = AdRevenuePrecision("unknown")
+
+        public fun fromString(value: String): AdRevenuePrecision {
+            return when (value.lowercase().trim()) {
+                "exact" -> EXACT
+                "publisher_defined" -> PUBLISHER_DEFINED
+                "estimated" -> ESTIMATED
+                "unknown" -> UNKNOWN
+                else -> AdRevenuePrecision(value)
+            }
+        }
     }
 }

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
@@ -53,7 +53,7 @@ public class AdRevenuePrecision internal constructor(@property:InternalRevenueCa
          */
         public val UNKNOWN: AdRevenuePrecision = AdRevenuePrecision("unknown")
 
-        public fun fromString(value: String): AdRevenuePrecision {
+        internal fun fromString(value: String): AdRevenuePrecision {
             return when (value.lowercase().trim()) {
                 "exact" -> EXACT
                 "publisher_defined" -> PUBLISHER_DEFINED

--- a/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/AdEventTypesTest.kt
+++ b/models/src/commonTest/kotlin/com/revenuecat/purchases/kmp/models/AdEventTypesTest.kt
@@ -1,11 +1,12 @@
 package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
+import com.revenuecat.purchases.kmp.InternalRevenueCatApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
-@OptIn(ExperimentalRevenueCatApi::class)
+@OptIn(ExperimentalRevenueCatApi::class, InternalRevenueCatApi::class)
 class AdEventTypesTest {
 
     @Test


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Description

Closing public construction of AdFormat/AdMediatorName/AdRevenuePrecision to match Android's style. To do this I copied the `InternalRevenueCatApi` annotation from the Kotlin package.

<!-- Describe your changes in detail -->

<!-- Please describe in detail how you tested your changes -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a public ABI break for experimental ad APIs (constructors and `value` access). Low runtime risk, but consumers constructing these types from strings will no longer compile.
> 
> **Overview**
> Makes `AdFormat`, `AdMediatorName`, and `AdRevenuePrecision` closed types: constructors are now `internal`, and `value` is marked with a new **`InternalRevenueCatApi`** opt-in (error-level). Callers should use companion constants instead of constructing from strings.
> 
> Adds `equals`/`hashCode` based on `value`, plus internal `fromString` helpers that map known values to the constants (unknown strings still create a custom instance). Platform mappings opt into the internal API when converting to Android/iOS types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56617d31818dee734519ad0d02fae3bc38dc317b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->