### PR TITLE
ci: bump dependency-submission to v4.4.3 for SHA pinning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "pallares/pin-dependency-submission-action" ]
 
 jobs:
   dependency-submission:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main
 
 on:
   push:
-    branches: [ "main", "pallares/pin-dependency-submission-action" ]
+    branches: [ "main" ]
 
 jobs:
   dependency-submission:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,4 +20,4 @@ jobs:
     # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
     # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
     - name: Generate and submit dependency graph
-      uses: gradle/actions/dependency-submission@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+      uses: gradle/actions/dependency-submission@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 7fbbe6656995ac24dddb0c426843c870301074c7
+  revision: 7dd9ab9d33986d253aef7393dcc7b2097177e2f3
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
       nokogiri


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android`, `purchases-ios` and other hybrids

### Motivation

The Main workflow's `dependency-submission` job fails org SHA-pinning: v3.1.0 is a composite that calls `setup-gradle@v3.1.0` by tag.

### Description

v4.4.3 is a JavaScript action with no nested `uses:`. v4 also uploads the graph as a workflow artifact.

### Notes

Verified green on this branch: https://github.com/RevenueCat/purchases-kmp/actions/runs/32224584237

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow dependency version bump with no application code changes; CI behavior should remain equivalent aside from v4 artifact upload behavior.
> 
> **Overview**
> Updates the Main workflow **Generate and submit dependency graph** step from `gradle/actions/dependency-submission` **v3.1.0** to **v4.4.3** (pinned to the same commit as other `gradle/actions` steps in this file).
> 
> This aligns the dependency-submission job with org SHA-pinning rules: v3.1.0 is a composite action that references nested actions by tag. v4.4.3 is a JavaScript action without nested `uses`, and v4 also uploads the dependency graph as a workflow artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bf048b70935235ef30154e86286723bea127b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->