### PR TITLE
renovate: force a release when native SDKs are bumped

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,28 @@
       "matchManagers": ["gradle"],
       "enabled": true,
       "groupName": "purchases-android"
+    },
+    {
+      "description": "Force a patch release when the native SDKs get a patch update",
+      "matchManagers": ["gradle", "git-submodules"],
+      "matchPackageNames": [
+        "com.revenuecat.purchases:purchases",
+        "com.revenuecat.purchases:purchases-ui",
+        "upstream/purchases-ios"
+      ],
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["pr:force_patch"]
+    },
+    {
+      "description": "Force a minor release when the native SDKs get a minor update",
+      "matchManagers": ["gradle", "git-submodules"],
+      "matchPackageNames": [
+        "com.revenuecat.purchases:purchases",
+        "com.revenuecat.purchases:purchases-ui",
+        "upstream/purchases-ios"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["pr:force_minor"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -20,24 +20,36 @@
       "groupName": "purchases-android"
     },
     {
-      "description": "Force a patch release when the native SDKs get a patch update",
-      "matchManagers": ["gradle", "git-submodules"],
+      "description": "Force a patch release when purchases-android gets a patch update",
+      "matchManagers": ["gradle"],
       "matchPackageNames": [
         "com.revenuecat.purchases:purchases",
-        "com.revenuecat.purchases:purchases-ui",
-        "upstream/purchases-ios"
+        "com.revenuecat.purchases:purchases-ui"
       ],
       "matchUpdateTypes": ["patch"],
       "addLabels": ["pr:force_patch"]
     },
     {
-      "description": "Force a minor release when the native SDKs get a minor update",
-      "matchManagers": ["gradle", "git-submodules"],
+      "description": "Force a minor release when purchases-android gets a minor update",
+      "matchManagers": ["gradle"],
       "matchPackageNames": [
         "com.revenuecat.purchases:purchases",
-        "com.revenuecat.purchases:purchases-ui",
-        "upstream/purchases-ios"
+        "com.revenuecat.purchases:purchases-ui"
       ],
+      "matchUpdateTypes": ["minor"],
+      "addLabels": ["pr:force_minor"]
+    },
+    {
+      "description": "Force a patch release when purchases-ios gets a patch update",
+      "matchManagers": ["git-submodules"],
+      "matchDepNames": ["upstream/purchases-ios"],
+      "matchUpdateTypes": ["patch"],
+      "addLabels": ["pr:force_patch"]
+    },
+    {
+      "description": "Force a minor release when purchases-ios gets a minor update",
+      "matchManagers": ["git-submodules"],
+      "matchDepNames": ["upstream/purchases-ios"],
       "matchUpdateTypes": ["minor"],
       "addLabels": ["pr:force_minor"]
     }


### PR DESCRIPTION
### Motivation
KMP's native SDK bumps come from Renovate (purchases-android via gradle, purchases-ios via git submodule) and carry only the inherited `pr:dependencies` label. Since RevenueCat/fastlane-plugin-revenuecat_internal#147 makes `pr:dependencies` release-neutral, those bumps stopped triggering a KMP release. This restores that behavior.

### Summary
- Add `pr:force_patch` / `pr:force_minor` (by Renovate update type) to the `purchases-android` and `purchases-ios` update PRs, keeping `pr:dependencies` for Danger and changelog categorization.
- Major native bumps get no force label, so they no longer auto-release and must be handled intentionally.

### Notes
- Companion to plugin PR #147 and RevenueCat/purchases-hybrid-common#1781 (PHC's equivalent fix, done in its Fastfile bump lane).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Renovate labels; no runtime or SDK code paths are modified.
> 
> **Overview**
> Adds Renovate `packageRules` so **patch** and **minor** bumps of `purchases-android` (Gradle) and `purchases-ios` (git submodule) get **`pr:force_patch`** or **`pr:force_minor`** on the PR, alongside the existing **`pr:dependencies`** label.
> 
> That restores automatic KMP releases when native SDKs are bumped via Renovate, after release tooling treated dependency-only PRs as release-neutral. **Major** native updates still get no force label, so they do not auto-release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d131e367f067a9ea23853cb3be41c4b84d384b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->