### PR TITLE
Update sdks-common-config orb to v4.6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ version: 2.1
 
 orbs:
   android: circleci/android@2.5.0
-  revenuecat: revenuecat/sdks-common-config@4.5.1
+  revenuecat: revenuecat/sdks-common-config@4.6.1
 
 commands:
   install-android-sdk-on-macos:


### PR DESCRIPTION
### Motivation

Keep CI on the latest shared orb release: [v4.6.1](https://github.com/RevenueCat/sdks-circleci-orb/releases/tag/v4.6.1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI orb version pin change with no application or security logic. Shared orb jobs (danger, release train, error codes) may pick up upstream orb behavior.
> 
> **Overview**
> Bumps the CircleCI `revenuecat/sdks-common-config` orb from **4.5.1** to **4.6.1** so CI uses the latest shared SDK config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376a5f7acccacd8f4e365b987715ca48991d0cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->