### PR TITLE
chore: poko for data classes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.jetbrains.compose).apply(false)
     alias(libs.plugins.compose.compiler).apply(false)
     alias(libs.plugins.kotlin.multiplatform).apply(false)
+    alias(libs.plugins.poko).apply(false)
     alias(libs.plugins.kotlinx.binaryCompatibilityValidator)
     alias(libs.plugins.adamko.dokkatoo.html)
     alias(libs.plugins.arturbosch.detekt).apply(false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ java = "1.8"
 junit = "5.10.0"
 kotlin = "2.3.20"
 mavenPublish = "0.33.0"
+poko = "0.22.0"
 revenuecat-android = "10.16.2"
 revenuecat-kmp = "3.6.0-SNAPSHOT"
 
@@ -49,4 +50,5 @@ jetbrains-compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.17.0" }
+poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }

--- a/models/api/models.api
+++ b/models/api/models.api
@@ -29,6 +29,7 @@ public final class com/revenuecat/purchases/kmp/models/AdFormat {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/revenuecat/purchases/kmp/models/AdFormat$Companion {
@@ -57,6 +58,7 @@ public final class com/revenuecat/purchases/kmp/models/AdMediatorName {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/revenuecat/purchases/kmp/models/AdMediatorName$Companion {
@@ -94,6 +96,7 @@ public final class com/revenuecat/purchases/kmp/models/AdRevenuePrecision {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/revenuecat/purchases/kmp/models/AdRevenuePrecision$Companion {

--- a/models/api/models.klib.api
+++ b/models/api/models.klib.api
@@ -577,6 +577,7 @@ final class com.revenuecat.purchases.kmp.models/AdFormat { // com.revenuecat.pur
 
     final fun equals(kotlin/Any?): kotlin/Boolean // com.revenuecat.purchases.kmp.models/AdFormat.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.revenuecat.purchases.kmp.models/AdFormat.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.revenuecat.purchases.kmp.models/AdFormat.toString|toString(){}[0]
 
     final object Companion { // com.revenuecat.purchases.kmp.models/AdFormat.Companion|null[0]
         final val APP_OPEN // com.revenuecat.purchases.kmp.models/AdFormat.Companion.APP_OPEN|{}APP_OPEN[0]
@@ -619,6 +620,7 @@ final class com.revenuecat.purchases.kmp.models/AdMediatorName { // com.revenuec
 
     final fun equals(kotlin/Any?): kotlin/Boolean // com.revenuecat.purchases.kmp.models/AdMediatorName.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.revenuecat.purchases.kmp.models/AdMediatorName.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.revenuecat.purchases.kmp.models/AdMediatorName.toString|toString(){}[0]
 
     final object Companion { // com.revenuecat.purchases.kmp.models/AdMediatorName.Companion|null[0]
         final val AD_MOB // com.revenuecat.purchases.kmp.models/AdMediatorName.Companion.AD_MOB|{}AD_MOB[0]
@@ -674,6 +676,7 @@ final class com.revenuecat.purchases.kmp.models/AdRevenuePrecision { // com.reve
 
     final fun equals(kotlin/Any?): kotlin/Boolean // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.toString|toString(){}[0]
 
     final object Companion { // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.Companion|null[0]
         final val ESTIMATED // com.revenuecat.purchases.kmp.models/AdRevenuePrecision.Companion.ESTIMATED|{}ESTIMATED[0]

--- a/models/build.gradle.kts
+++ b/models/build.gradle.kts
@@ -2,6 +2,7 @@ import com.revenuecat.purchases.kmp.buildlogic.watchosTargets
 
 plugins {
     id("revenuecat-library")
+    alias(libs.plugins.poko)
 }
 
 revenueCat {

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdFormat.kt
@@ -2,24 +2,14 @@ package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
 import com.revenuecat.purchases.kmp.InternalRevenueCatApi
+import dev.drewhamilton.poko.Poko
 
 /**
  * Common ad format types.
  */
 @ExperimentalRevenueCatApi
+@Poko
 public class AdFormat internal constructor(@property:InternalRevenueCatApi public val value: String) {
-    @OptIn(InternalRevenueCatApi::class)
-    public override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is AdFormat) return false
-        return value == other.value
-    }
-
-    @OptIn(InternalRevenueCatApi::class)
-    public override fun hashCode(): Int {
-        return value.hashCode()
-    }
-
     public companion object {
         public val OTHER: AdFormat = AdFormat("other")
         public val BANNER: AdFormat = AdFormat("banner")

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdMediatorName.kt
@@ -2,24 +2,14 @@ package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
 import com.revenuecat.purchases.kmp.InternalRevenueCatApi
+import dev.drewhamilton.poko.Poko
 
 /**
  * Common ad mediator names.
  */
 @ExperimentalRevenueCatApi
+@Poko
 public class AdMediatorName internal constructor(@property:InternalRevenueCatApi public val value: String) {
-    @OptIn(InternalRevenueCatApi::class)
-    public override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is AdMediatorName) return false
-        return value == other.value
-    }
-
-    @OptIn(InternalRevenueCatApi::class)
-    public override fun hashCode(): Int {
-        return value.hashCode()
-    }
-
     public companion object {
         public val AD_MOB: AdMediatorName = AdMediatorName("AdMob")
         public val APP_LOVIN: AdMediatorName = AdMediatorName("AppLovin")

--- a/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
+++ b/models/src/commonMain/kotlin/com/revenuecat/purchases/kmp/models/AdRevenuePrecision.kt
@@ -2,6 +2,7 @@ package com.revenuecat.purchases.kmp.models
 
 import com.revenuecat.purchases.kmp.ExperimentalRevenueCatApi
 import com.revenuecat.purchases.kmp.InternalRevenueCatApi
+import dev.drewhamilton.poko.Poko
 
 /**
  * Represents the precision level of ad revenue values reported by ad networks.
@@ -10,19 +11,8 @@ import com.revenuecat.purchases.kmp.InternalRevenueCatApi
  * This enum helps distinguish between exact reported values and estimates.
  */
 @ExperimentalRevenueCatApi
+@Poko
 public class AdRevenuePrecision internal constructor(@property:InternalRevenueCatApi public val value: String) {
-    @OptIn(InternalRevenueCatApi::class)
-    public override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is AdRevenuePrecision) return false
-        return value == other.value
-    }
-
-    @OptIn(InternalRevenueCatApi::class)
-    public override fun hashCode(): Int {
-        return value.hashCode()
-    }
-
     public companion object {
         /**
          * The revenue value is exact and confirmed by the ad network.


### PR DESCRIPTION
### Description

Replacing custom `equals` and `hashCode` with `@poko` annotation for ads related plain data objects - mirroring what we do in the android sdk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time codegen refactor of experimental ad value types. Public ABI grows by `toString()`, but equality semantics should stay the same.
> 
> **Overview**
> Replaces hand-written `equals`/`hashCode` on `AdFormat`, `AdMediatorName`, and `AdRevenuePrecision` with `@Poko`, matching the Android SDK approach.
> 
> Adds the Poko Gradle plugin (`0.22.0`) to the models module. Generated `toString()` is now part of the public ABI for these types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa71d1b636a5706f630c4283574290693a02ebc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->