### PR TITLE
ci: notify external PRs feed on PRs from outside the org

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -1,0 +1,13 @@
+name: External PR Notifications
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    secrets:
+      EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a workflow that posts to an internal Slack feed when a PR is opened by someone outside the RevenueCat org.
- Uses `pull_request_target` so the job has the webhook secret on fork PRs; it never checks out or runs PR code and holds a `GITHUB_TOKEN` with no permissions.


### Checklist

- [x] `actionlint` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification-only CI with no repo permissions; `pull_request_target` is used deliberately for fork PR secrets, with mitigation via empty permissions and a pinned reusable workflow.
> 
> **Overview**
> Adds a GitHub Actions workflow that alerts an internal Slack channel when an **external contributor opens a PR**.
> 
> The workflow runs on `pull_request_target` with `types: [opened]` so fork PRs can use the webhook secret without running untrusted code in-repo. It sets **`permissions: {}`** on the caller and delegates to the shared **`revenuecat/sdk-github-workflows`** `external-pr-notifications` reusable workflow (pinned to **v7**), passing **`EXTERNAL_PR_SLACK_WEBHOOK_URL`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572f3a22021ec22d8dd77c048ff77a9287bbf0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->