### PR TITLE
ci: bump external PR notifications workflow to v8

### DIFF
--- a/.github/workflows/external-pr-notifications.yml
+++ b/.github/workflows/external-pr-notifications.yml
@@ -8,6 +8,6 @@ permissions: {}
 
 jobs:
   notify:
-    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@3765ddb1c650fba52875e793217f737727425bdf # v7
+    uses: revenuecat/sdk-github-workflows/.github/workflows/external-pr-notifications.yml@b679120ce2931ac2e5c02166f84ad1f9b263fb96 # v8
     secrets:
       EXTERNAL_PR_SLACK_WEBHOOK_URL: ${{ secrets.EXTERNAL_PR_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Bumps the shared workflow to `v8`, which gates on `head.repo.fork` instead of `author_association` so PRs from org members with private membership stop being posted as external. See RevenueCat/sdk-github-workflows#11.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow version bump with no application code changes; only affects when Slack notifications fire for opened PRs.
> 
> **Overview**
> Updates the **External PR Notifications** reusable workflow pin from **v7** to **v8** of `revenuecat/sdk-github-workflows`.
> 
> The behavior change lives in the shared workflow: notifications now treat a PR as external based on **`head.repo.fork`** rather than **`author_association`**, so contributors who are org members but have **private membership** are no longer misclassified as external and spammed to Slack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f00b28cb2954471e9295ec888407edefd9a8f21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->